### PR TITLE
Fixed a Regression in FSD Handling Backspace

### DIFF
--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -1126,7 +1126,7 @@ namespace MBBSEmu.CPU
         [MethodImpl(OpcodeCompilerOptimizations)]
         private void Op_Cwd()
         {
-            Registers.DX = Registers.AX.IsBitSet(15) ? (ushort)0xFFFF : (ushort)0x0000;
+            Registers.DX = Registers.AX.IsBitSet(15) ? 0xFFFF : 0x0000;
         }
 
 

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -6438,7 +6438,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var sbleng = GetParameter(2);
             var answers = GetParameterPointer(3);
 
-            var fsdAnswersPointer = Module.Memory.GetOrAllocateVariablePointer($"FDS-Answers-{ChannelNumber}", 0x800);
+            var fsdAnswersPointer = Module.Memory.GetOrAllocateVariablePointer($"FSD-Answers-{ChannelNumber}", 0x800);
 
             Module.Memory.SetZero(fsdAnswersPointer, 0x800);
 

--- a/MBBSEmu/HostProcess/HostRoutines/FsdRoutines.cs
+++ b/MBBSEmu/HostProcess/HostRoutines/FsdRoutines.cs
@@ -349,6 +349,10 @@ namespace MBBSEmu.HostProcess.HostRoutines
         private ushort SetUserInput(SessionBase session)
         {
             var userInput = session.InputBuffer.ToArray();
+
+            if (userInput.Length == 0 && session.CharacterProcessed == 0x8)
+                userInput = new byte[] {0x8};
+
             switch (userInput.Length)
             {
                 case 3 when userInput[0] == 0x1B && userInput[1] == '[': //ANSI Sequence
@@ -548,6 +552,8 @@ namespace MBBSEmu.HostProcess.HostRoutines
                             {
                                 _fsdFields[session.Channel].SelectedField.Value =
                                     _fsdFields[session.Channel].SelectedField.Value.Substring(0, _fsdFields[session.Channel].SelectedField.Value.Length - 1);
+
+                                session.SendToClient(new byte[] { 0x08, 0x20, 0x08 });
                             }
 
                             break;


### PR DESCRIPTION
- Because Backspace isn't added to the InputBuffer and handled in `ProcessIncomingCharacter`, we have to detect if it's the case in FSD and handle it there as well
- Fixed Typo
- Removed redundant cast in CPU Core