### PR TITLE
Int21h get current directory

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/intdos_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/intdos_Tests.cs
@@ -297,8 +297,8 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             var testRegisters = new CpuRegisters {AH = 0x47};
 
             var dirPointer = mbbsEmuMemoryCore.AllocateVariable("DIR-POINTER", 10);
-            testRegisters.DS = dirPointer.Segment;
-            testRegisters.SI = dirPointer.Offset;
+            mbbsEmuCpuRegisters.DS = dirPointer.Segment;
+            testRegisters.DI = dirPointer.Offset;
 
             //Allocate some memory to hold the test data
             var testRegistersArrayData = testRegisters.ToRegs();
@@ -316,8 +316,9 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             //Verify Results
             Assert.Equal(0, testRegisters.AX);
             Assert.Equal(0, testRegisters.DL);
-            Assert.Equal(4096, testRegisters.DS);
-            Assert.Equal(40238, testRegisters.SI);
+            Assert.Equal(dirPointer.Segment, mbbsEmuCpuRegisters.DS);
+            Assert.Equal(dirPointer.Offset, testRegisters.DI);
+            Assert.Equal("BBSV6\\", Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString(testRegisters.DS, testRegisters.DI, true)));
         }
 
         [Fact]

--- a/MBBSEmu/DOS/Interrupts/Int21h.cs
+++ b/MBBSEmu/DOS/Interrupts/Int21h.cs
@@ -240,7 +240,7 @@ namespace MBBSEmu.DOS.Interrupts
                             AX = error code
                             Note: the returned path does not include the initial backslash
                          */
-                        _memory.SetArray(_registers.DS, _registers.SI, Encoding.ASCII.GetBytes("BBSV6\\\0"));
+                        _memory.SetArray(_registers.DS, _registers.DI, Encoding.ASCII.GetBytes("BBSV6\\\0"));
                         _registers.AX = 0;
                         _registers.DL = 0;
                         _registers.F = _registers.F.ClearFlag((ushort)EnumFlags.CF);

--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -720,7 +720,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                         var resultRegisters = Module.Execute(variableEntryPoint, ChannelNumber, true, true, null, 0xF100);
                         var variableData = Module.Memory.GetString(resultRegisters.DX, resultRegisters.AX, true);
 #if DEBUG
-                        _logger.Debug(($"({Module.ModuleIdentifier}) Processing Text Variable {textVariableName} ({variableEntryPoint}): {BitConverter.ToString(variableData.ToArray()).Replace("-", " ")}");
+                        _logger.Debug(($"({Module.ModuleIdentifier}) Processing Text Variable {textVariableName} ({variableEntryPoint}): {BitConverter.ToString(variableData.ToArray()).Replace("-", " ")}"));
 #endif
                         newOutputBuffer.Write(variableData);
                         break;


### PR DESCRIPTION
Fixes INT 21h 0x47 Test (GetCurrentDirectory)

![image](https://user-images.githubusercontent.com/1139047/106345989-bad8b680-6281-11eb-86f0-524951e1e67a.png)

Assumption that DS is set prior to the call, as it's not part of the REGS struct.

```c
struct WORDREGS
{
    unsigned short ax; __PADDING
    unsigned short bx; __PADDING
    unsigned short cx; __PADDING
    unsigned short dx; __PADDING
    unsigned short si; __PADDING
    unsigned short di; __PADDING
    unsigned short cflag;
    unsigned short flags;
};

struct BYTEREGS
{
    unsigned char al;
    unsigned char ah; __PADDING
    unsigned char bl;
    unsigned char bh; __PADDING
    unsigned char cl;
    unsigned char ch; __PADDING
    unsigned char dl;
    unsigned char dh; __PADDING
};

union REGS
{
#if defined(__DPMI32__)
    struct  DWORDREGS x;
#else
    struct  WORDREGS  x;
#endif
    struct  WORDREGS  w;
    struct  BYTEREGS  h;
};
```