### PR TITLE
Test Adds/Coverage - setmem(), issupc(), cncchr(), alcmem(), alczer() and keytests

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/alcmem_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/alcmem_Tests.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class alcmem_Tests : ExportedModuleTestBase
+    {
+        private const int ALCMEM_ORDINAL = 65;
+
+        [Theory]
+        [InlineData(3)]
+        [InlineData(72)]
+        [InlineData(45)]
+        [InlineData(0)]
+        public void alcmem_Test(ushort numBytes)
+        {
+            //Reset State
+            Reset();
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, ALCMEM_ORDINAL, new List<ushort> { numBytes });
+
+            //Verify Results
+            var expected = new byte[numBytes];
+
+            for (var i = 0; i < numBytes; i++)
+                expected[i] = 0x0;
+
+            var dstArray = mbbsEmuMemoryCore.GetArray(mbbsEmuCpuRegisters.GetPointer(), numBytes);
+
+            //Verify Results
+            Assert.Equal(expected, dstArray.ToArray());
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/alcmem_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/alcmem_Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace MBBSEmu.Tests.ExportedModules.Majorbbs
@@ -12,6 +13,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData(72)]
         [InlineData(45)]
         [InlineData(0)]
+        [InlineData(39000)]
         public void alcmem_Test(ushort numBytes)
         {
             //Reset State
@@ -22,13 +24,10 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Verify Results
             var expected = new byte[numBytes];
-
-            for (var i = 0; i < numBytes; i++)
-                expected[i] = 0x0;
+            Array.Fill(expected, (byte)0x0);
 
             var dstArray = mbbsEmuMemoryCore.GetArray(mbbsEmuCpuRegisters.GetPointer(), numBytes);
 
-            //Verify Results
             Assert.Equal(expected, dstArray.ToArray());
         }
     }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/alczer_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/alczer_Tests.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class alczer_Tests : ExportedModuleTestBase
+    {
+        private const int ALCZER_ORDINAL = 68;
+
+        [Theory]
+        [InlineData(3)]
+        [InlineData(72)]
+        [InlineData(45)]
+        [InlineData(0)]
+        public void alczer_Test(ushort numBytes)
+        {
+            //Reset State
+            Reset();
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, ALCZER_ORDINAL, new List<ushort> { numBytes });
+
+            //Verify Results
+            var expected = new byte[numBytes];
+
+            for (var i = 0; i < numBytes; i++)
+                expected[i] = 0x0;
+
+            var dstArray = mbbsEmuMemoryCore.GetArray(mbbsEmuCpuRegisters.GetPointer(), numBytes);
+
+            //Verify Results
+            Assert.Equal(expected, dstArray.ToArray());
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/alczer_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/alczer_Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace MBBSEmu.Tests.ExportedModules.Majorbbs
@@ -12,6 +13,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData(72)]
         [InlineData(45)]
         [InlineData(0)]
+        [InlineData(44000)]
         public void alczer_Test(ushort numBytes)
         {
             //Reset State
@@ -22,13 +24,10 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Verify Results
             var expected = new byte[numBytes];
-
-            for (var i = 0; i < numBytes; i++)
-                expected[i] = 0x0;
+            Array.Fill(expected, (byte)0x0);
 
             var dstArray = mbbsEmuMemoryCore.GetArray(mbbsEmuCpuRegisters.GetPointer(), numBytes);
 
-            //Verify Results
             Assert.Equal(expected, dstArray.ToArray());
         }
     }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/cncchr_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/cncchr_Tests.cs
@@ -1,7 +1,6 @@
-﻿using System;
+﻿using MBBSEmu.Memory;
 using System.Collections.Generic;
 using System.Text;
-using MBBSEmu.Memory;
 using Xunit;
 
 namespace MBBSEmu.Tests.ExportedModules.Majorbbs
@@ -19,6 +18,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("123    456\0", 3, '4', 8)]
         [InlineData("123\0", 3, '\0', 3)]
         [InlineData("\0", 0, '\0', 0)]
+        [InlineData("123\0", 4, '\0', 4)]
         public void cncchr_Test(string inputString, ushort nxtcmdStartingOffset, char expectedResult, ushort expectedNxtcmdOffset)
         {
             //Reset State

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/issupc_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/issupc_Tests.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class issupc_Tests : ExportedModuleTestBase
+    {
+        private const int ISSUPC_ORDINAL = 362;
+
+        [Theory]
+        [InlineData(31, 0)]
+        [InlineData('!', 0)]
+        [InlineData('A', 1)]
+        [InlineData('a', 1)]
+        [InlineData('Z', 1)]
+        [InlineData('z', 1)]
+        [InlineData('0', 1)]
+        [InlineData('@', 0)]
+        [InlineData('~', 1)]
+        [InlineData(127, 0)]
+        public void issupc_Test(byte input, ushort expectedValue)
+        {
+            //Reset State
+            Reset();
+
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, ISSUPC_ORDINAL, new List<ushort> { input });
+
+            //Verify Results
+            Assert.Equal(expectedValue, mbbsEmuCpuRegisters.AX);
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/key_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/key_Tests.cs
@@ -29,7 +29,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Set Argument Values to be Passed In
             var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(key.Length + 1));
-            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes("SYSOP"));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes(key));
 
             //Execute Test
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, HASKEY_ORDINAL, new List<FarPtr> { stringPointer });
@@ -50,7 +50,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Set Argument Values to be Passed In
             var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(key.Length + 1));
-            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes("SYSOP"));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes(key));
 
             //Execute Test
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, GEN_HASKEY_ORDINAL, new List<ushort> { stringPointer.Offset, stringPointer.Segment, testSessions[0].Channel });
@@ -71,7 +71,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Set Argument Values to be Passed In
             var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(key.Length + 1));
-            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes("SYSOP"));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes(key));
 
             mbbsEmuMemoryCore.SetWord("OTHUSN", 0);
 
@@ -137,7 +137,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Set Argument Values to be Passed In
             var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(key.Length + 1));
-            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes("SYSOP"));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes(key));
 
             //Execute Test
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, HASKEY_ORDINAL, new List<FarPtr> { stringPointer });
@@ -158,7 +158,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Set Argument Values to be Passed In
             var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(key.Length + 1));
-            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes("SYSOP"));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes(key));
 
             //Execute Test
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, GEN_HASKEY_ORDINAL, new List<ushort> { stringPointer.Offset, stringPointer.Segment, testSessions[0].Channel });
@@ -179,7 +179,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Set Argument Values to be Passed In
             var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(key.Length + 1));
-            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes("SYSOP"));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes(key));
 
             mbbsEmuMemoryCore.SetWord("OTHUSN", 0);
 
@@ -231,6 +231,49 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Execute Test
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, UIDKEY_ORDINAL, new List<FarPtr> { usernamePointer, keyPointer });
+
+            Assert.Equal(1, mbbsEmuCpuRegisters.AX);
+
+        }
+
+        [Fact]
+        public void hasmkey_Rloginuser_Test()
+        {
+            //Reset State
+            Reset();
+
+            //Set the test Username
+            testSessions[0].Username = "rloginUser";
+            var key = "NORMAL";
+
+            var mcvPointer = (ushort)majorbbs.McvPointerDictionary.Allocate(new McvFile("TEST.MCV",
+                new Dictionary<int, byte[]> { { 0, Encoding.ASCII.GetBytes(key) } }));
+
+            mbbsEmuMemoryCore.SetPointer("CURRENT-MCV", new FarPtr(0xFFFF, mcvPointer));
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, HASMKEY_ORDINAL, new List<ushort> { 0 });
+
+            Assert.Equal(1, mbbsEmuCpuRegisters.AX);
+
+        }
+
+        [Fact]
+        public void haskey_rloginUser_Test()
+        {
+            //Reset State
+            Reset();
+
+            //Set the test Username
+            testSessions[0].Username = "rloginUser";
+            var key = "NORMAL";
+
+            //Set Argument Values to be Passed In
+            var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(key.Length + 1));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes(key));
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, HASKEY_ORDINAL, new List<FarPtr> { stringPointer });
 
             Assert.Equal(1, mbbsEmuCpuRegisters.AX);
 

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/key_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/key_Tests.cs
@@ -237,7 +237,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         }
 
         [Fact]
-        public void hasmkey_Rloginuser_Test()
+        public void hasmkey_rloginUser_Test()
         {
             //Reset State
             Reset();

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/memset_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/memset_Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace MBBSEmu.Tests.ExportedModules.Majorbbs
@@ -36,9 +37,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Verify Results
             var expected = new byte[memSize];
-
-            for (var i = 0; i < memSize; i++)
-                expected[i] = (byte) valueToFill;
+            Array.Fill(expected, (byte)valueToFill);
             
             var dstArray = mbbsEmuMemoryCore.GetArray("SETMEMORY", memSize);
 

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/setmem_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/setmem_Tests.cs
@@ -1,0 +1,52 @@
+﻿using MBBSEmu.Memory;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class setmem_Tests : ExportedModuleTestBase
+    {
+        private const int SETMEM_ORDINAL = 544;
+
+        [Theory]
+        [InlineData(new byte[] { 0x4, 0x4 }, 0x3, 2)]
+        [InlineData(new byte[] { 0x4, 0x4, 0x3, 0x2 }, 0x3, 4)]
+        [InlineData(new byte[] { 0x4, 0x4, 0x3, 0x2, 0x1, 0x0 }, 0xE, 6)]
+        [InlineData(new byte[] { 0x4 }, 0x0, 1)]
+        [InlineData(new byte[] { }, 0x0, 0)]
+        [InlineData(new byte[] { 0xE, 0xF, 0x2, 0x8 }, 0xA, 4)]
+        public void memset_Test(byte[] bufMem, ushort valueToFill, ushort memSize)
+        {
+            //Reset State
+            Reset();
+
+            //Set Argument Values to be Passed In -- Signature: void setmem(char *destination, unsigned nbytes, char value)
+            var bufPointer = mbbsEmuMemoryCore.AllocateVariable("SETMEMORY", (ushort)bufMem.Length);
+            mbbsEmuMemoryCore.SetArray(bufPointer, bufMem);
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment,
+                SETMEM_ORDINAL,
+                new List<ushort>
+                {
+                    bufPointer.Offset,
+                    bufPointer.Segment,
+                    memSize,
+                    valueToFill
+                });
+
+            //Verify Results
+            var expected = new byte[memSize];
+
+            for (var i = 0; i < memSize; i++)
+                expected[i] = (byte)valueToFill;
+
+            var dstArray = mbbsEmuMemoryCore.GetArray("SETMEMORY", memSize);
+
+            Assert.Equal(bufPointer.Segment, mbbsEmuCpuRegisters.DX);
+            Assert.Equal(bufPointer.Offset, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(expected, dstArray.ToArray());
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/setmem_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/setmem_Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace MBBSEmu.Tests.ExportedModules.Majorbbs
@@ -19,7 +20,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             //Reset State
             Reset();
 
-            //Set Argument Values to be Passed In -- Signature: void setmem(char *destination, unsigned nbytes, char value)
+            //Set Argument Values to be Passed In
             var bufPointer = mbbsEmuMemoryCore.AllocateVariable("SETMEMORY", (ushort)bufMem.Length);
             mbbsEmuMemoryCore.SetArray(bufPointer, bufMem);
 
@@ -36,11 +37,9 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Verify Results
             var expected = new byte[numBytes];
+            Array.Fill(expected, (byte)valueToFill);
 
-            for (var i = 0; i < numBytes; i++)
-                expected[i] = (byte)valueToFill;
-
-            var dstArray = mbbsEmuMemoryCore.GetArray("SETMEMORY", numBytes);
+            var dstArray = mbbsEmuMemoryCore.GetArray(bufPointer, numBytes);
 
             Assert.Equal(expected, dstArray.ToArray());
         }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/setmem_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/setmem_Tests.cs
@@ -1,6 +1,4 @@
-﻿using MBBSEmu.Memory;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using Xunit;
 
 namespace MBBSEmu.Tests.ExportedModules.Majorbbs
@@ -10,13 +8,13 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         private const int SETMEM_ORDINAL = 544;
 
         [Theory]
-        [InlineData(new byte[] { 0x4, 0x4 }, 0x3, 2)]
-        [InlineData(new byte[] { 0x4, 0x4, 0x3, 0x2 }, 0x3, 4)]
-        [InlineData(new byte[] { 0x4, 0x4, 0x3, 0x2, 0x1, 0x0 }, 0xE, 6)]
-        [InlineData(new byte[] { 0x4 }, 0x0, 1)]
-        [InlineData(new byte[] { }, 0x0, 0)]
-        [InlineData(new byte[] { 0xE, 0xF, 0x2, 0x8 }, 0xA, 4)]
-        public void memset_Test(byte[] bufMem, ushort valueToFill, ushort memSize)
+        [InlineData(new byte[] { 0x4, 0x4 }, 2, 0x3)]
+        [InlineData(new byte[] { 0x4, 0x4, 0x3, 0x2 }, 4, 0x3)]
+        [InlineData(new byte[] { 0x4, 0x4, 0x3, 0x2, 0x1, 0x0 }, 6, 0xE)]
+        [InlineData(new byte[] { 0x4 }, 1, 0x0)]
+        [InlineData(new byte[] { }, 0, 0x0)]
+        [InlineData(new byte[] { 0xE, 0xF, 0x2, 0x8 }, 4, 0xA)]
+        public void setmem_Test(byte[] bufMem, ushort numBytes, ushort valueToFill)
         {
             //Reset State
             Reset();
@@ -32,20 +30,18 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
                 {
                     bufPointer.Offset,
                     bufPointer.Segment,
-                    memSize,
+                    numBytes,
                     valueToFill
                 });
 
             //Verify Results
-            var expected = new byte[memSize];
+            var expected = new byte[numBytes];
 
-            for (var i = 0; i < memSize; i++)
+            for (var i = 0; i < numBytes; i++)
                 expected[i] = (byte)valueToFill;
 
-            var dstArray = mbbsEmuMemoryCore.GetArray("SETMEMORY", memSize);
+            var dstArray = mbbsEmuMemoryCore.GetArray("SETMEMORY", numBytes);
 
-            Assert.Equal(bufPointer.Segment, mbbsEmuCpuRegisters.DX);
-            Assert.Equal(bufPointer.Offset, mbbsEmuCpuRegisters.AX);
             Assert.Equal(expected, dstArray.ToArray());
         }
     }

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -3581,11 +3581,6 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var numberOfBytesToFill = GetParameter(3);
 
             Module.Memory.FillArray(destinationPointer, numberOfBytesToFill, (byte)valueToFill);
-            //for (var i = 0; i < numberOfBytesToFill; i++)
-            //{
-            //    Module.Memory.SetByte(destinationPointer.Segment, (ushort)(destinationPointer.Offset + i),
-            //        (byte)valueToFill);
-           // }
 
             Registers.SetPointer(destinationPointer);
 #if DEBUG

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -2775,14 +2775,14 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// <returns></returns>
         private void setmem()
         {
-            var destination = GetParameterPointer(0);
+            var destinationPointer = GetParameterPointer(0);
             var numberOfBytesToWrite = GetParameter(2);
             var byteToWrite = GetParameter(3);
 
-            for (var i = 0; i < numberOfBytesToWrite; i++)
-            {
-                Module.Memory.SetByte(destination.Segment, (ushort)(destination.Offset + i), (byte)byteToWrite);
-            }
+            Module.Memory.FillArray(destinationPointer, numberOfBytesToWrite, (byte)byteToWrite);
+#if DEBUG
+            _logger.Debug($"({Module.ModuleIdentifier}) Set {numberOfBytesToWrite} bytes at {destinationPointer} with {(byte)byteToWrite:X2}");
+#endif
         }
 
         /// <summary>
@@ -3578,17 +3578,18 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             var destinationPointer = GetParameterPointer(0);
             var valueToFill = GetParameter(2);
-            var numberOfByteToFill = GetParameter(3);
+            var numberOfBytesToFill = GetParameter(3);
 
-            for (var i = 0; i < numberOfByteToFill; i++)
-            {
-                Module.Memory.SetByte(destinationPointer.Segment, (ushort)(destinationPointer.Offset + i),
-                    (byte)valueToFill);
-            }
+            Module.Memory.FillArray(destinationPointer, numberOfBytesToFill, (byte)valueToFill);
+            //for (var i = 0; i < numberOfBytesToFill; i++)
+            //{
+            //    Module.Memory.SetByte(destinationPointer.Segment, (ushort)(destinationPointer.Offset + i),
+            //        (byte)valueToFill);
+           // }
 
             Registers.SetPointer(destinationPointer);
 #if DEBUG
-            _logger.Debug($"({Module.ModuleIdentifier}) Filled {numberOfByteToFill} bytes at {destinationPointer} with {(byte)valueToFill:X2}");
+            _logger.Debug($"({Module.ModuleIdentifier}) Filled {numberOfBytesToFill} bytes at {destinationPointer} with {(byte)valueToFill:X2}");
 #endif
         }
 


### PR DESCRIPTION
-Add setmem() tests
-Add issupc() tests
-cncchr() test, added new theory to get 100% coverage of ordinal
-Add alcmem() tests
-Add alczer() tests
-key_Tests fixes/adds
----Added 2 more scenarios in key_Tests to give full test coverage (rlogin user, blank key)
----Changed hardcodes to variables in a few places which I think were cut/pasted
-Update setmem(), memset() ordinals to use Module.Memory.FillArray