### PR TITLE
Don't put "extra" bits into terminal, log as debug

### DIFF
--- a/MBBSEmu/Session/Rlogin/RloginSession.cs
+++ b/MBBSEmu/Session/Rlogin/RloginSession.cs
@@ -121,9 +121,9 @@ namespace MBBSEmu.Session.Rlogin
             {
                 if (ProcessIncomingByte(clientData[i]))
                 {
-                    // return whatever data we may have left in the packet as client data
+                    // data left in the packet seems to do more harm than good, so we are tossing it, but adding to debug log 
                     var remaining = bytesReceived - i - 1;
-                    return (clientData.TakeLast(remaining).ToArray(), remaining);
+                    _logger.Debug($"Tossing extra data \"{System.Text.Encoding.UTF8.GetString(clientData.TakeLast(remaining).ToArray())}\"");
                 }
             }
 

--- a/MBBSEmu/Session/Rlogin/RloginSession.cs
+++ b/MBBSEmu/Session/Rlogin/RloginSession.cs
@@ -123,7 +123,7 @@ namespace MBBSEmu.Session.Rlogin
                 {
                     // data left in the packet seems to do more harm than good, so we are tossing it, but adding to debug log 
                     var remaining = bytesReceived - i - 1;
-                    _logger.Debug($"Tossing extra data \"{System.Text.Encoding.ASCII.GetString(clientData.TakeLast(remaining).ToArray())}\"");
+                    _logger.Debug($"Ignoring extra rlogin data: \"{System.Text.Encoding.ASCII.GetString(clientData.TakeLast(remaining).ToArray())}\"");
                 }
             }
 

--- a/MBBSEmu/Session/Rlogin/RloginSession.cs
+++ b/MBBSEmu/Session/Rlogin/RloginSession.cs
@@ -123,7 +123,7 @@ namespace MBBSEmu.Session.Rlogin
                 {
                     // data left in the packet seems to do more harm than good, so we are tossing it, but adding to debug log 
                     var remaining = bytesReceived - i - 1;
-                    _logger.Debug($"Tossing extra data \"{System.Text.Encoding.UTF8.GetString(clientData.TakeLast(remaining).ToArray())}\"");
+                    _logger.Debug($"Tossing extra data \"{System.Text.Encoding.ASCII.GetString(clientData.TakeLast(remaining).ToArray())}\"");
                 }
             }
 


### PR DESCRIPTION
We have been seeing random characters jammed into the terminal after a rlogin connection. This seems to be because we are taking some extra handshake bits and treating them as input. I don't think this is doing anything good, and is def doing some annoying things, so I have changed the rlogin code to instead log those bits to Debug. I believe this will fix issue #130 .