### PR TITLE
Fix rlogin to always call lonrou for all modules

### DIFF
--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -552,10 +552,7 @@ namespace MBBSEmu.HostProcess
         {
             session.OutputEnabled = false; // always disabled for RLogin
 
-            var entryPoint = session.CurrentModule.MainModuleDll.EntryPoints["lonrou"];
-
-            if (entryPoint != FarPtr.Empty)
-                Run(session.CurrentModule.ModuleIdentifier, entryPoint, session.Channel);
+            CallModuleRoutine("lonrou", preRunCallback: null, session.Channel);
 
             session.SessionState = EnumSessionState.EnteringModule;
             session.OutputEnabled = true;


### PR DESCRIPTION
lonrou should should be called by rlogin for all modules, even if only one being directly accessed. This is good for house / record keeping, and to avoid corruption when huprou is called on all the modules when the session ends.