### PR TITLE
Test Coverage, removed ordinal checks unreachable

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/cnclon_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/cnclon_Tests.cs
@@ -64,6 +64,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("abc 123", 3, 123, 7)]
         [InlineData("abc -123", 3, -123, 8)]
         [InlineData("", 0, 0, 0)]
+        [InlineData(" ", 0, 0, 0)]
         public void cncint_Test(string inputString, ushort nxtcmdStartingOffset, short expectedResult, ushort expectedNxtcmdOffset)
         {
             //Reset State

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/cncsig_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/cncsig_Tests.cs
@@ -19,6 +19,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("/MyUserNameIsTooLong\0", 0, "/MyUserNa", 9, "meIsTooLong")]
         [InlineData("123456789012345678901234567890\0", 0, "/12345678", 8, "9012345678901234567890")]
         [InlineData("\0", 0, "", 0, "")]
+        [InlineData("OneSixSix                Hello              \0", 8, "/x", 25, "Hello              ")]
         public void cncsig_Test(string inputString, ushort nxtcmdStartingOffset, string expectedResult, ushort expectedNxtcmdOffset, string expectedNxtcmdRemaining)
         {
             //Reset State

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/cncwrd_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/cncwrd_Tests.cs
@@ -16,6 +16,8 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("FIRST SECOND THIRD\0", 13, "THIRD", 19)]
         [InlineData("123456789012345678901234567890\0", 0, "12345678901234567890123456789", 30)] //Test Truncation
         [InlineData("\0", 0, "", 0)]
+        [InlineData("OneSixSix                Hello              \0", 8, "x", 25)]
+        [InlineData("                FIRST SECOND\0", 0, "FIRST", 22)]
         public void cncwrd_Test(string inputString, ushort nxtcmdStartingOffset, string expectedResult, ushort expectedNxtcmdOffset)
         {
             //Reset State

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/cncyesno_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/cncyesno_Tests.cs
@@ -11,7 +11,6 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         private const int CNCYESNO_ORDINAL = 131;
 
         [Theory]
-
         //Simple commands with nxtcmd == input
         [InlineData("YES", 0, 'Y', 4)]
         [InlineData("Y", 0, 'Y', 2)]
@@ -24,6 +23,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("N TEST", 0, 'N', 2)]
         [InlineData("NO THIS IS A TEST", 0, 'N', 3)]
         [InlineData("TEST NO", 0, 'T', 0)]
+        [InlineData("", 0, 0, 0)]
 
         //Incremented nxtcmd Tests
         [InlineData("TEST NO", 5, 'N', 3)]

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/cncyesno_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/cncyesno_Tests.cs
@@ -11,6 +11,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         private const int CNCYESNO_ORDINAL = 131;
 
         [Theory]
+
         //Simple commands with nxtcmd == input
         [InlineData("YES", 0, 'Y', 4)]
         [InlineData("Y", 0, 'Y', 2)]

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -5556,6 +5556,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var inputString = Encoding.ASCII.GetString(Module.Memory.GetArray(nxtcmdPointer, (ushort)remainingCharactersInCommand));
 
             IEnumerator<char> charEnumerator = inputString.GetEnumerator();
+            charEnumerator.MoveNext();
 
             var (moreInput, skipped) = ConsumeWhitespace(charEnumerator);
             if (!moreInput)

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -5556,11 +5556,6 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var inputString = Encoding.ASCII.GetString(Module.Memory.GetArray(nxtcmdPointer, (ushort)remainingCharactersInCommand));
 
             IEnumerator<char> charEnumerator = inputString.GetEnumerator();
-            if (!charEnumerator.MoveNext())
-            {
-                cncint_ErrorResult(returnType);
-                return;
-            }
 
             var (moreInput, skipped) = ConsumeWhitespace(charEnumerator);
             if (!moreInput)
@@ -7283,12 +7278,6 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             var inputString = Module.Memory.GetArray(nxtcmdPointer, (ushort)remainingCharactersInCommand);
             var inputStringComponents = Encoding.ASCII.GetString(inputString).ToUpper().Split('\0');
-
-            if (inputStringComponents.Length == 0)
-            {
-                Registers.AX = 0;
-                return;
-            }
 
             switch (inputStringComponents[0])
             {


### PR DESCRIPTION
-cncint() coverage 100%
-cncsig() coverage 100%
-cncwrd() coverage 100%
-cncyesno() coverage 100%
-Removed cncint() MoveNext check, could not trip
-Removed cncyesno() inputStringComponents check, could not trip