### PR TITLE
Multiple Open Perfection

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/file_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/file_Tests.cs
@@ -432,13 +432,12 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             Assert.Equal(0, fseek(filep, 0, 0));
 
             Assert.Equal(0, fseek(filep, fseekOffset, originNum));
-            Assert.Equal(0, fseek(filep2, fseekOffset, originNum));
-
             Assert.Equal(expectedChar, fgetc(filep));
-            Assert.Equal(expectedChar, fgetc(filep2));
-
-            Assert.Equal(0, fclose(filep2));
             Assert.Equal(0, fclose(filep));
+
+            Assert.Equal(0, fseek(filep2, fseekOffset, originNum));
+            Assert.Equal(expectedChar, fgetc(filep2));
+            Assert.Equal(0, fclose(filep2));
         }
 
         [Theory]

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/file_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/file_Tests.cs
@@ -406,6 +406,48 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData(25, 't', 1)]
         [InlineData(55, ',', 1)]
         [InlineData(-1, '\n', 2)]
+        [InlineData(-3, '.', 2)]
+        [InlineData(-12, 'c', 2)]
+        [InlineData(-22, 'u', 2)]
+        [InlineData(-27, 't', 2)]
+        [InlineData(-57, 'c', 2)]
+        public void fgetc_fseek_origin1and2_file_double_open(int fseekOffset, byte expectedChar, ushort originNum)
+        {
+            //Reset State
+            Reset();
+
+            var filePath = CreateTextFile("file.txt", LOREM_IPSUM);
+
+            Assert.Equal(LOREM_IPSUM.Length, new FileInfo(filePath).Length);
+
+            var filep = fopen("FILE.TXT", "rt");
+            Assert.NotEqual(0, filep.Segment);
+            Assert.NotEqual(0, filep.Offset);
+
+            var filep2 = fopen("FILE.TXT", "rb");
+            Assert.NotEqual(0, filep2.Segment);
+            Assert.NotEqual(0, filep2.Offset);
+
+            Assert.Equal(0, fseek(filep2, 0, 0));
+            Assert.Equal(0, fseek(filep, 0, 0));
+
+            Assert.Equal(0, fseek(filep, fseekOffset, originNum));
+            Assert.Equal(0, fseek(filep2, fseekOffset, originNum));
+
+            Assert.Equal(expectedChar, fgetc(filep));
+            Assert.Equal(expectedChar, fgetc(filep2));
+
+            Assert.Equal(0, fclose(filep2));
+            Assert.Equal(0, fclose(filep));
+        }
+
+        [Theory]
+        [InlineData(4, 'm', 1)]
+        [InlineData(10, 'm', 1)]
+        [InlineData(20, 't', 1)]
+        [InlineData(25, 't', 1)]
+        [InlineData(55, ',', 1)]
+        [InlineData(-1, '\n', 2)]
         [InlineData(-2, '\n', 2)]
         [InlineData(-3, '.', 2)]
         [InlineData(-12, 'c', 2)]

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -3153,9 +3153,6 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var fileStruct = new FileStruct();
             Module.Memory.SetArray(fileStructPointer, fileStruct.Data);
 
-            // Setup struct flags
-            fileStruct.SetFlags(fileAccessMode);
-
             //Setup the File Stream
             fileStream ??= File.Open(fullPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite);
 
@@ -3165,7 +3162,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var fileStreamPointer = FilePointerDictionary.Allocate(fileStream);
 
             //Set Struct Values
-            
+            fileStruct.SetFlags(fileAccessMode);
             fileStruct.curp = new FarPtr(ushort.MaxValue, (ushort)fileStreamPointer);
             fileStruct.fd = (byte)fileStreamPointer;
             Module.Memory.SetArray(fileStructPointer, fileStruct.Data);

--- a/MBBSEmu/HostProcess/Structs/FileStruct.cs
+++ b/MBBSEmu/HostProcess/Structs/FileStruct.cs
@@ -108,13 +108,7 @@ namespace MBBSEmu.HostProcess.Structs
             set => Array.Copy(BitConverter.GetBytes(value), 0, Data, 17, 2);
         }
 
-        public byte ref_count
-        {
-            get => Data[19];
-            set => Data[19] = value;
-        }
-
-        public const ushort Size = 20;
+        public const ushort Size = 19;
 
         public byte[] Data = new byte[Size];
 

--- a/MBBSEmu/HostProcess/Structs/FileStruct.cs
+++ b/MBBSEmu/HostProcess/Structs/FileStruct.cs
@@ -108,7 +108,13 @@ namespace MBBSEmu.HostProcess.Structs
             set => Array.Copy(BitConverter.GetBytes(value), 0, Data, 17, 2);
         }
 
-        public const ushort Size = 19;
+        public byte ref_count
+        {
+            get => Data[19];
+            set => Data[19] = value;
+        }
+
+        public const ushort Size = 20;
 
         public byte[] Data = new byte[Size];
 


### PR DESCRIPTION
I added a ref_count to the file struct that stops us from destroying it until it is the last usage. 

This was done to fix the double opens that were crashing Lords of Cyberspace per #143 . 

This is super basic, I would not be stunned if something could cause it to lose track or leave a bunch of memory in use.

That said, it does work and it does fix the cleanup for Lords of Cyberspace.

I won't be offended if you hate it, just let me know how it should be done. Let's call it a proof of concept. ;)