### PR TITLE
Fixes to handle unescaped `%` in printf string

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/prf_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/prf_Tests.cs
@@ -36,6 +36,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("Mid 50% Test", "Mid 50% Test", null)] //Unescaped %
         [InlineData("End 50% ", "End 50% ", null)] //Unescaped %
         [InlineData("End 50%", "End 50%", null)] //Unescaped %
+        [InlineData("This is 100%% accurate", "This is 100% accurate", null)] //Escaped %
         public void prf_Test(string inputString, string expectedString, params object[] values)
         {
             Reset();

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/prf_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/prf_Tests.cs
@@ -32,6 +32,10 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("%s-%ld-%d-%s", "TEST--1-1-FOO", "TEST", (uint)0xFFFFFFFF, (ushort)1, "FOO")]
         [InlineData("%s-%lu-%d-%s", "TEST-2147483647-1-FOO", "TEST", 2147483647u, (ushort)1, "FOO")]
         [InlineData("%s-%lu-%d-%s", "TEST-3147483647-1-FOO", "TEST", 3147483647u, (ushort)1, "FOO")]
+        [InlineData("99% of the time, this will print %s", "99% of the time, this will print TEST", "TEST")] //Unescaped %
+        [InlineData("Mid 50% Test", "Mid 50% Test", null)] //Unescaped %
+        [InlineData("End 50% ", "End 50% ", null)] //Unescaped %
+        [InlineData("End 50%", "End 50%", null)] //Unescaped %
         public void prf_Test(string inputString, string expectedString, params object[] values)
         {
             Reset();
@@ -41,9 +45,12 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             parameters.Add(inputStingParameterPointer.Offset);
             parameters.Add(inputStingParameterPointer.Segment);
 
-            var parameterList = GenerateParameters(values);
-            foreach (var p in parameterList)
-                parameters.Add(p);
+            if (values != null)
+            {
+                var parameterList = GenerateParameters(values);
+                foreach (var p in parameterList)
+                    parameters.Add(p);
+            }
 
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, PRF_ORDINAL, parameters);
 

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/prf_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/prf_Tests.cs
@@ -37,6 +37,9 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("End 50% ", "End 50% ", null)] //Unescaped %
         [InlineData("End 50%", "End 50%", null)] //Unescaped %
         [InlineData("This is 100%% accurate", "This is 100% accurate", null)] //Escaped %
+        [InlineData("%%%%", "%%", null)] //Escaped %
+        [InlineData("%%%%%", "%%%", null)] //Escaped & Unescaped %
+        [InlineData("%%%%% ", "%%% ", null)] //Escaped & Unescaped %
         public void prf_Test(string inputString, string expectedString, params object[] values)
         {
             Reset();

--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -293,11 +293,17 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             for (var i = 0; i < stringToParse.Length; i++)
             {
+                var controlStart = i;
+
                 //Handle escaped %% as a single % -- or if % is the last character in a string
                 if (stringToParse[i] == '%')
                 {
                     switch ((char)stringToParse[i + 1])
                     {
+                        case ' ': //Single % followed by space
+                            msOutput.WriteByte(stringToParse[i]);
+                            continue;
+
                         case '%': //escaped %
                             msOutput.WriteByte((byte)'%');
                             i++;
@@ -609,8 +615,11 @@ namespace MBBSEmu.HostProcess.ExportedModules
                                 break;
                             }
                         default:
-                            throw new InvalidDataException(
-                                $"({Module.ModuleIdentifier}) Unhandled Printf Control Character: {(char)stringToParse[i + 1]}");
+                        {
+                            _logger.Warn($"({Module.ModuleIdentifier}) Unhandled Printf Control Character: {(char) stringToParse[i + 1]}");
+                            msOutput.Write(stringToParse.Slice(controlStart, (i - controlStart) + 1));
+                            continue;
+                        }
                     }
 
                     //Process Padding


### PR DESCRIPTION
Fixes #421 printf issue

Added a couple cases, specifically if the string has a trailing space and then if it would throw an exception for an invalid specifier. Now it just echos back out the control string and logs a warning.