### PR TITLE
Add Tests f_printf(), fclose(), getmsgs(), morcnc(), read(), write(), open() for 100% coverage

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/file_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/file_Tests.cs
@@ -701,5 +701,38 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             //Pass empty pointer
             Assert.Throws<FileNotFoundException>(() => fseek(FarPtr.Empty, 0, 0));
         }
+
+        [Fact]
+        public void fprintf_InvalidStream_Throw()
+        {
+            //Reset State
+            Reset();
+
+            //Pass empty pointer
+            Assert.Throws<FileNotFoundException>(() => f_printf(FarPtr.Empty, "%s", LOREM_IPSUM.Substring(0, 1)));
+        }
+
+        [Fact]
+        public void fclose_SegmentNotInDictionary()
+        {
+            //Reset State
+            Reset();
+
+            var filePath = CreateTextFile("filesegment.txt", LOREM_IPSUM);
+
+            Assert.Equal(LOREM_IPSUM.Length, new FileInfo(filePath).Length);
+
+            var filep = fopen("FILESEGMENT.TXT", "a");
+            Assert.NotEqual(0, filep.Segment);
+            Assert.NotEqual(0, filep.Offset);
+
+            //Clear Dictionary
+            majorbbs.FilePointerDictionary.Clear();
+
+            //Pass in file pointer that was cleared from dictionary
+            fclose(filep);
+
+            Assert.Equal(0xFFFF, mbbsEmuCpuRegisters.AX);
+        }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/getmsg_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/getmsg_Tests.cs
@@ -1,0 +1,32 @@
+﻿using MBBSEmu.Memory;
+using MBBSEmu.Module;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class getmsg_Tests : ExportedModuleTestBase
+    {
+        private const int GETMSG_ORDINAL = 326;
+
+        [Fact]
+        public void getmsg_over1000_Test()
+        {
+            //Reset State
+            Reset();
+
+            var input = string.Concat(Enumerable.Repeat("ab", 3000));
+
+            var mcvPointer = (ushort)majorbbs.McvPointerDictionary.Allocate(new McvFile("TEST.MCV",
+                new Dictionary<int, byte[]> { { 0, Encoding.ASCII.GetBytes(input) } }));
+
+            mbbsEmuMemoryCore.SetPointer("CURRENT-MCV", new FarPtr(0xFFFF, mcvPointer));
+
+            //Verify Results
+            Assert.Throws<Exception>(() => ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, GETMSG_ORDINAL, new List<ushort> { 0 }));
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/morcnc_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/morcnc_Tests.cs
@@ -17,8 +17,8 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("123 456\0", 4, '4', 4)]
         [InlineData("123    456\0", 4, '4', 7)]
         [InlineData("123\0", 3, '\0', 3)]
-        [InlineData("\0", 0, '\0', 0)]
-        public void cncchr_Test(string inputString, ushort nxtcmdStartingOffset, char expectedResult, ushort expectedNxtcmdOffset)
+        [InlineData("", 0, '\0', 0)]
+        public void morcnc_Test(string inputString, ushort nxtcmdStartingOffset, char expectedResult, ushort expectedNxtcmdOffset)
         {
             //Reset State
             Reset();

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/posix_file_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/posix_file_Tests.cs
@@ -3,6 +3,7 @@ using MBBSEmu.HostProcess.Structs;
 using System;
 using System.IO;
 using System.Text;
+using MBBSEmu.Memory;
 using Xunit;
 
 namespace MBBSEmu.Tests.ExportedModules.Majorbbs
@@ -256,6 +257,30 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             Reset();
 
             close(6).Should().Be(0xFFFF);
+        }
+
+        [Fact]
+        public void read_invalidHandle()
+        {
+            Reset();
+
+            read(6, FarPtr.Empty, 1).Should().Be(0xFFFF);
+        }
+
+        [Fact]
+        public void write_invalidHandle()
+        {
+            Reset();
+
+            write(6, FarPtr.Empty, 1).Should().Be(0xFFFF);
+        }
+
+        [Fact]
+        public void open_text_fails()
+        {
+            Reset();
+
+            Assert.Throws<ArgumentException>(() => open("Dummy.txt", EnumOpenFlags.O_TEXT));
         }
     }
 }

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -3900,7 +3900,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var fileStruct = new FileStruct(Module.Memory.GetArray(fileStructPointer, FileStruct.Size));
 
             if (!FilePointerDictionary.TryGetValue(fileStruct.curp.Offset, out var fileStream))
-                throw new Exception($"Unable to locate FileStream for {fileStructPointer} (Stream: {fileStruct.curp})");
+                throw new FileNotFoundException($"Unable to locate FileStream for {fileStructPointer} (Stream: {fileStruct.curp})");
 
             var output = Module.Memory.GetString(sourcePointer, true);
 


### PR DESCRIPTION
*Add f_printf() filenotfound throw test
*Add fclose() pointer not in dictionary test
*Add getmgs() overflow test
*Add morcnc() test for null
*Add read() invalid handle test
*Add write() invalid handle test
*Add open() text not supported test
*Change f_printf() exception