### PR TITLE
Fix broken tests on Linux

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/cntdir_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/cntdir_Tests.cs
@@ -69,16 +69,16 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             Reset();
 
             // create 1 empty file
-            CreateFile("/subdir/test.dat");
-            CreateFile("/subdir/test1.dat");
-            CreateFile("/subdir/test2.dat");
-            CreateFile("/subdir/xxx.dat");
-            CreateFile("/subdir/hello.dat");
+            CreateFile("subdir/test.dat");
+            CreateFile("subdir/test1.dat");
+            CreateFile("subdir/test2.dat");
+            CreateFile("subdir/xxx.dat");
+            CreateFile("subdir/hello.dat");
 
             //Pointer to sub directory
             var subdirPointer = mbbsEmuMemoryCore.AllocateVariable("STR", 64);
 
-            mbbsEmuMemoryCore.SetArray(subdirPointer, Encoding.ASCII.GetBytes("/subdir/*"));
+            mbbsEmuMemoryCore.SetArray(subdirPointer, Encoding.ASCII.GetBytes("subdir/*"));
 
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, CNTDIR_ORDINAL, new List<FarPtr>() { subdirPointer });
 

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/rename_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/rename_Tests.cs
@@ -22,17 +22,17 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         }
 
         [Theory]
-        [InlineData("oldname.dat", "newname.dat", 0, false)]
-        [InlineData("o.txt", "longname.dat", 0, false)]
-        [InlineData("a", "b", 0, false)]
-        [InlineData("oldname.dat", "newname.dat", 65535, true)]
-        [InlineData("", "newname.dat", 65535, true)]
-        [InlineData("oldfile.txt", "", 65535, true)]
-        public void rename_file_Test(string oldFileName, string newFileName, ushort axValue, bool shouldThrowException)
+        [InlineData("oldname.dat", "NEWNAME.DAT", 0)]
+        [InlineData("o.txt", "LONGNAM.DAT", 0)]
+        [InlineData("a", "B", 0)]
+        [InlineData("oldname.dat", "NEWNAME.DAT", 65535)]
+        [InlineData("", "NEWNAME.DAT", 65535)]
+        [InlineData("oldfile.txt", "", 65535)]
+        public void rename_file_Test(string oldFileName, string newFileName, ushort axValue)
         {
             Reset();
 
-            if(!shouldThrowException)
+            if(axValue == 0)
                 CreateFile(oldFileName);
             
             //Pointer to old and new filenames
@@ -42,18 +42,10 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             var toNamePointer = mbbsEmuMemoryCore.AllocateVariable("TO_NAME", (ushort) (newFileName.Length + 1));
             mbbsEmuMemoryCore.SetArray(toNamePointer, Encoding.ASCII.GetBytes(newFileName));
 
-            try
-            {
-                ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, RENAME_ORDINAL, new List<FarPtr> {fromNamePointer, toNamePointer});
-            }
-            catch (Exception)
-            {
-                Assert.True(shouldThrowException);
-                Assert.Equal(axValue, mbbsEmuCpuRegisters.AX);
-            }
-
-            Assert.NotEqual(shouldThrowException, File.Exists(mbbsModule.ModulePath + newFileName));
-            Assert.Equal(axValue, mbbsEmuCpuRegisters.AX);
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, RENAME_ORDINAL, new List<FarPtr> {fromNamePointer, toNamePointer});
+            
+            Assert.Equal(axValue, mbbsEmuCpuRegisters.AX);    
+            Assert.Equal(axValue == 0, File.Exists(Path.Combine(mbbsModule.ModulePath, newFileName)));
         }
 
         private void CreateFile(string file)

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -6039,7 +6039,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             var pathPointer = GetParameterPointer(0);
 
-            var pathString = _fileFinder.FindFile(Module.ModulePath, GetParameterFilename(0));
+            var pathString = _fileFinder.ResolvePathWithWildcards(Module.ModulePath, GetParameterFilename(0));
 
             var files = Directory.GetFiles(Module.ModulePath, pathString);
             uint totalBytes = 0;

--- a/MBBSEmu/IO/IFileUtility.cs
+++ b/MBBSEmu/IO/IFileUtility.cs
@@ -3,6 +3,7 @@
     public interface IFileUtility
     {
         string FindFile(string modulePath, string fileName);
+        string ResolvePathWithWildcards(string modulePath, string filePath);
         string CorrectPathSeparator(string fileName);
     }
 }


### PR DESCRIPTION
Needed to expect `CAPITAL` files in rename, and cntdir couldn't handle case of `subdir/*` since it was expanding the path to subdir/first_file and not preserving the wildcards. 