### PR TITLE
Fixed issue when string null terminator was last byte in Segment

### DIFF
--- a/MBBSEmu.Tests/Memory/MemoryCore_Tests.cs
+++ b/MBBSEmu.Tests/Memory/MemoryCore_Tests.cs
@@ -1,0 +1,31 @@
+﻿using MBBSEmu.DependencyInjection;
+using MBBSEmu.Memory;
+using NLog;
+using System.Text;
+using Xunit;
+
+namespace MBBSEmu.Tests.Memory
+{
+    public class MemoryCore_Tests : TestBase
+    {
+        private readonly ILogger _logger = new ServiceResolver().GetService<ILogger>();
+
+        [Fact]
+        public void EndOfSegmentString()
+        {
+            ushort segment = 1;
+            var memoryCore = new MemoryCore(_logger);
+            memoryCore.AddSegment(segment);
+
+            var testString = new string('X', 5) + "\0";
+            var testStringOffset = (ushort)(ushort.MaxValue - testString.Length + 1);
+
+            memoryCore.SetArray(1, testStringOffset, Encoding.ASCII.GetBytes(testString));
+
+            var stringFromMemory = Encoding.ASCII.GetString(memoryCore.GetString(1, testStringOffset, stripNull: false));
+
+            Assert.Equal(testString, stringFromMemory);
+
+        }
+    }
+}

--- a/MBBSEmu/Memory/MemoryCore.cs
+++ b/MBBSEmu/Memory/MemoryCore.cs
@@ -444,7 +444,7 @@ namespace MBBSEmu.Memory
         {
             ReadOnlySpan<byte> segmentSpan = _memorySegments[segment];
 
-            for (var i = offset; i < ushort.MaxValue; i++)
+            for (int i = offset; i <= ushort.MaxValue; i++)
             {
                 if (segmentSpan[i] == 0x0)
                     return segmentSpan.Slice(offset, (i - offset) + (stripNull ? 0 : 1));


### PR DESCRIPTION
- `GetString` now will not throw an exception if the null terminator for a string is the last byte in a Segment
- Added Test for the scenario