### PR TITLE
Add EXE Name to Environment Segment after Variables

### DIFF
--- a/MBBSEmu/DOS/ExeRuntime.cs
+++ b/MBBSEmu/DOS/ExeRuntime.cs
@@ -145,7 +145,10 @@ namespace MBBSEmu.DOS
                 bytesWritten += (ushort)(str.Length);
             }
             // null terminate
-            Memory.SetWord(ENVIRONMENT_SEGMENT, bytesWritten, 0);
+            Memory.SetByte(ENVIRONMENT_SEGMENT, bytesWritten++, 0);
+
+            //Add EXE 
+            Memory.SetArray(ENVIRONMENT_SEGMENT, bytesWritten, Encoding.ASCII.GetBytes(File.ExeFile + "\0"));
         }
     }
 }


### PR DESCRIPTION
Clears an Abnormal Abort on Borland TC++ Library Function which loads the EXE name at runtime

![image](https://user-images.githubusercontent.com/1139047/111916837-40dbd700-8a53-11eb-84ea-c24b14e1127c.png)