### PR TITLE
Use LocalConsole with ExeRuntime based on -CONSOLE

### DIFF
--- a/MBBSEmu/Program.cs
+++ b/MBBSEmu/Program.cs
@@ -229,9 +229,25 @@ namespace MBBSEmu
                 //EXE File Execution
                 if (!string.IsNullOrEmpty(_exeFile))
                 {
-                    var localSession = new LocalConsoleSession(_logger, "CONSOLE", null, null, false, false);
                     var mzFile = new MZFile(_exeFile);
-                    var exe = new ExeRuntime(mzFile, _serviceResolver.GetService<IClock>(), _logger, _serviceResolver.GetService<IFileUtility>(), localSession);
+                    ExeRuntime exe;
+                    if (_isConsoleSession)
+                        exe = new ExeRuntime(
+                            mzFile,
+                            _serviceResolver.GetService<IClock>(),
+                            _logger,
+                            _serviceResolver.GetService<IFileUtility>(),
+                            new LocalConsoleSession(_logger, "CONSOLE", null, null, false, false));
+                    else
+                        exe = new ExeRuntime(
+                            mzFile,
+                            _serviceResolver.GetService<IClock>(),
+                            _logger,
+                            _serviceResolver.GetService<IFileUtility>(),
+                            sessionBase: null,
+                            new TextReaderStream(Console.In),
+                            new TextWriterStream(Console.Out),
+                            new TextWriterStream(Console.Error));
                     exe.Load(programArgs);
                     exe.Run();
                     return;


### PR DESCRIPTION
LocalConsole doesn't work so hot on Linux, and actually prevents debugging via vscode do to some exception being thrown about Console.Read.

If you want to use LocalConsole with an EXE, add `-CONSOLE` as an arg