### PR TITLE
Set EOF Flag if trying to fread() an empty file

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/file_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/file_Tests.cs
@@ -126,6 +126,29 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             Assert.Equal(-1, fclose(filep));
         }
 
+        [Fact]
+        public void fopen_emptyfile_read_verifyeof()
+        {
+            //Reset State
+            Reset();
+
+            var filePath = CreateTextFile("file.txt", string.Empty);
+
+            var filep = fopen("file.txt", "rb");
+            Assert.NotEqual(0, filep.Segment);
+            Assert.NotEqual(0, filep.Offset);
+
+            var memoryStream = new MemoryStream();
+            var dstBuf = mbbsEmuMemoryCore.AllocateVariable(null, 4096);
+
+            var elementsRead = fread(dstBuf, 1, 128, filep);
+
+            Assert.Equal(0, elementsRead);
+
+            var filepStruct = new FileStruct(mbbsEmuMemoryCore.GetArray(filep, FileStruct.Size));
+            Assert.True(filepStruct.flags.IsFlagSet((ushort)FileStruct.EnumFileFlags.EOF));
+        }
+
         [Theory]
         [InlineData("r", 2, 1)]
         [InlineData("r", 2, 2)]

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -3315,6 +3315,10 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             if (fileStream.Position >= fileStream.Length)
             {
+                //Set EOF Flag
+                fileStruct.flags |= (ushort)FileStruct.EnumFileFlags.EOF;
+                Module.Memory.SetArray(fileStructPointer, fileStruct.Data);
+
                 Registers.AX = 0;
                 return;
             }


### PR DESCRIPTION
- Set EOF Flag Properly when opening a file of 0 bytes and attempting to read

We were properly returning `0` on AX for elements read, but if the program is checking the file*, we need to also set the EOF flag on the struct to denote we're EOF. 

This was causing an issue in Distant Realms (`CCDDR`) where the `CCDDRPL.DAT` file was 0 bytes and it was looping a write to `DSPL.PRE` with a reused buffer, which would then continue to fill the `DSPL.PRE` file until it filled the disk because it never thought it reached EOF on `CCDDRPL.DAT`

Test Included

Fixes #386 