### PR TITLE
Fix NCTIME To Null Terminate

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/nctime_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/nctime_Tests.cs
@@ -9,15 +9,15 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         private const int NCTIME_ORDINAL = 430;
 
         [Theory]
-        [InlineData(12, 4, 10, "12:04:10", true)]
-        [InlineData(3, 9, 2, "03:09:02", false)]
-        [InlineData(4, 11, 15, "04:11:14", true)]
-        [InlineData(7, 5, 3, "07:05:02", false)]
-        [InlineData(10, 1, 28, "10:01:28", true)]
-        [InlineData(14, 3, 36, "14:03:36", false)]
-        [InlineData(18, 12, 7, "18:12:06", true)]
-        [InlineData(23, 1, 44, "23:01:44", false)]
-        [InlineData(23, 59, 58, "23:59:58", true)]
+        [InlineData(12, 4, 10, "12:04:10\0", true)]
+        [InlineData(3, 9, 2, "03:09:02\0", false)]
+        [InlineData(4, 11, 15, "04:11:14\0", true)]
+        [InlineData(7, 5, 3, "07:05:02\0", false)]
+        [InlineData(10, 1, 28, "10:01:28\0", true)]
+        [InlineData(14, 3, 36, "14:03:36\0", false)]
+        [InlineData(18, 12, 7, "18:12:06\0", true)]
+        [InlineData(23, 1, 44, "23:01:44\0", false)]
+        [InlineData(23, 59, 58, "23:59:58\0", true)]
         public void nctime_Test(int hour, int minutes, int seconds, string expectedTime, bool allocateNCTIME)
         {
             //Reset State
@@ -27,13 +27,17 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             var packedTime = hour << 11 | minutes << 5 | seconds >> 1;
 
             if (allocateNCTIME)
-                mbbsEmuMemoryCore.AllocateVariable("NCTIME", sizeof(int));
+                mbbsEmuMemoryCore.AllocateVariable("NCTIME", (ushort)expectedTime.Length);
 
             //Execute Test
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, NCTIME_ORDINAL, new List<ushort> { (ushort) packedTime });
 
+            //Put Garbage After it to ensure the null terminator catches
+            var garbagePointer = mbbsEmuMemoryCore.AllocateVariable("GARBAGE", 10);
+            mbbsEmuMemoryCore.SetArray(garbagePointer, Encoding.ASCII.GetBytes(new string('C', 10)));
+
             //Verify Results
-            Assert.Equal(expectedTime, Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString("NCTIME", true)));
+            Assert.Equal(expectedTime, Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString("NCTIME")));
         }
     }
 }

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -3986,7 +3986,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var unpackedTime = new DateTime(_clock.Now.Year, _clock.Now.Month, _clock.Now.Day, unpackedHour,
                 unpackedMinutes, unpackedSeconds);
 
-            var timeString = unpackedTime.ToString("HH:mm:ss");
+            var timeString = $"{unpackedTime.ToString("HH:mm:ss")}\0";
             var variablePointer = Module.Memory.GetOrAllocateVariablePointer("NCTIME", (ushort) timeString.Length);
 
             Module.Memory.SetArray(variablePointer.Segment, variablePointer.Offset,


### PR DESCRIPTION
- Added Null Terminator to string returned by NCTIME
- Fixed Unit Test to use the correct string length
- Modified Unit Test to put garbage string after NCTIME to ensure null terminator is working properly

Fixes #450 