### PR TITLE
Make Int 7Bh queries return KeyValueNotFound when necessary.

### DIFF
--- a/MBBSEmu/DOS/Interrupts/Int7Bh.cs
+++ b/MBBSEmu/DOS/Interrupts/Int7Bh.cs
@@ -24,7 +24,7 @@ namespace MBBSEmu.DOS.Interrupts
         InvalidKeyNumber = 6,
         DifferentKeyNumber = 7,
         InvalidPositioning = 8,
-        EOF = 9 ,
+        EOF = 9,
         NonModifiableKeyValue = 10,
         InvalidFileName = 11,
         FileNotFound = 12,
@@ -418,7 +418,7 @@ key-only file or a Get operation on a data only file */
                 key = _memory.GetArray(command.key_buffer_segment, command.key_buffer_offset, command.key_buffer_length);
 
             if (!db.PerformOperation(command.key_number, key, command.operation))
-                return BtrieveError.EOF;
+                return command.operation.RequiresKey() ? BtrieveError.KeyValueNotFound : BtrieveError.EOF;
 
             var data = db.GetRecord();
 


### PR DESCRIPTION
Queries that specify a key are searchin by key and KeyValueNotFound is a
better error than EOF. EOF is still used for queries that are
"key-less", such as Next/Previous. Those queries should return EOF.