### PR TITLE
Fix for MajorMUD 1.11p Help File (MSG)

### DIFF
--- a/MBBSEmu/Module/MsgFile.cs
+++ b/MBBSEmu/Module/MsgFile.cs
@@ -108,7 +108,7 @@ namespace MBBSEmu.Module
                     case MsgParseState.IDENTIFIER when IsIdentifier(c):
                         identifier.Append(c);
                         break;
-                    case MsgParseState.IDENTIFIER when c == '\r':
+                    case MsgParseState.IDENTIFIER when c is '\r' or '\n':
                         state = MsgParseState.JUNK;
                         break;
                     case MsgParseState.IDENTIFIER when char.IsWhiteSpace(c):

--- a/MBBSEmu/Module/MsgFile.cs
+++ b/MBBSEmu/Module/MsgFile.cs
@@ -49,7 +49,7 @@ namespace MBBSEmu.Module
         };
 
         private static bool IsIdentifier(char c) =>
-            char.IsDigit(c) || (c >= 'A' && c <= 'Z');
+            char.IsDigit(c) || (c is >= 'A' and <= 'Z');
 
         private static bool IsAlnum(char c) =>
             char.IsLetterOrDigit(c);
@@ -107,6 +107,9 @@ namespace MBBSEmu.Module
                         break;
                     case MsgParseState.IDENTIFIER when IsIdentifier(c):
                         identifier.Append(c);
+                        break;
+                    case MsgParseState.IDENTIFIER when c == '\r':
+                        state = MsgParseState.JUNK;
                         break;
                     case MsgParseState.IDENTIFIER when char.IsWhiteSpace(c):
                         state = MsgParseState.SPACE;


### PR DESCRIPTION
- Fixes mid-identification of data type of it's on its own line prior to the following identifier

MajorMUD 1.11p (WCCMMUD) uses a MSG file for parsing the help commands (using `sameto()`) and the help content. This file isn't exactly formatted consistently, specifically the MSG type definition is on its own line in several parts of the file:

![image](https://user-images.githubusercontent.com/1139047/116795274-cfeffc00-aaa1-11eb-9f44-5702d871e020.png)

vs

![image](https://user-images.githubusercontent.com/1139047/116795277-d9796400-aaa1-11eb-9e05-15afade8d104.png)

Because of this, our MSG parsing code was identifying the `String` string as the following identifier, and since it contained `spaces` and then alpha characters for the ACTUAL following identifier, it set the state to `JUNK` for the actual identifier when it was encountered. This caused the offset of the MSG ordinals to be off and all kinds of bad memory overflows to happen.

This SHOULD fix it, but it's not resilient as a MSG identifier followed by a `\r` before `{` will be thrown away as junk. This probably needs some testing.


