### PR TITLE
Swords of Chaos: Reset Status Change to False on Module Exit

### DIFF
--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -559,6 +559,7 @@ namespace MBBSEmu.HostProcess
             session.CurrentModule = null;
             session.CharacterInterceptor = null;
             session.PromptCharacter = 0;
+            session.StatusChange = false;
 
             //Reset States
             session.Status = 0;


### PR DESCRIPTION
- Was preventing Menu Commands from being processed after exiting Swords of Chaos for The Major BBS