### PR TITLE
Fix crash in FSD for Swords of Chaos

### DIFF
--- a/MBBSEmu/HostProcess/HostRoutines/FsdRoutines.cs
+++ b/MBBSEmu/HostProcess/HostRoutines/FsdRoutines.cs
@@ -291,6 +291,9 @@ namespace MBBSEmu.HostProcess.HostRoutines
         /// <param name="errorField"></param>
         private void ClearErrorMessage(SessionBase session, FsdFieldSpec errorField)
         {
+            if (errorField == null)
+                return;
+
             session.SendToClient($"\x1B[0;1m");
 
             SetCursorPosition(session, errorField.X, errorField.Y);


### PR DESCRIPTION
- Swords of Chaos FSD template was missing an error field definition (which, to date, has been on every FSD template), because of this, the code assumed it would always be there.

Added a `null` check in `ClearErrorMessage()` to verify if the field definition is null or not before proceeding.

Fixes #483 