### PR TITLE
Only Trigger "Status Changed" if Status == 240 or 5

### DIFF
--- a/MBBSEmu/HostProcess/ExportedModules/Galgsbl.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Galgsbl.cs
@@ -321,9 +321,9 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             //Status Change
             //Set the Memory Value
-            Module.Memory.SetWord(Module.Memory.GetVariablePointer("STATUS"), status);
+            Module.Memory.SetWord("STATUS", status);
 
-            //Notify the Session that a Status Change has occured
+            //Notify the Session that a Status Change has occurred
             channel.StatusChange = true;
 
 #if DEBUG

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -400,7 +400,11 @@ namespace MBBSEmu.HostProcess.ExportedModules
             }
             else if (ChannelDictionary[ChannelNumber].StatusChange)
             {
-                ChannelDictionary[ChannelNumber].Status = Module.Memory.GetWord(Module.Memory.GetVariablePointer("STATUS"));
+                ChannelDictionary[ChannelNumber].Status = Module.Memory.GetWord("STATUS");
+
+                //We only want to trigger status change when deferred execution is set
+                if (ChannelDictionary[ChannelNumber].Status is not 240 or 5)
+                    ChannelDictionary[ChannelNumber].StatusChange = false;
             }
             else
             {

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -340,7 +340,7 @@ namespace MBBSEmu.HostProcess
 
 
                                 //Did BTUCHI or a previous command cause a status change?
-                                if (session.StatusChange && (session.Status == 240 || session.Status == 5))
+                                if (session.StatusChange && session.Status is 240 or 5)
                                 {
                                     ProcessSTSROU(session);
                                     break;


### PR DESCRIPTION
Lunatix would call `btuinj` on entry and set the status to `240` (deferred execution). This would trigger the `StatusChanged` property. Because of this, input wouldn't be processed. I've added code to only trigger the `StatusChanged` property if it's set to deferred execution, otherwise handle it as regular input.

There's potentially a larger refactor that needs to happen here, where channel `Status` is handled as a FIFO queue, because Lunatix is calling `btuinj` to set `Status` of `240`, then setting status of `1` on routine "exit". This means the first actual status read from the channel SHOULD be `240`, which would trigger `stsrou`. 

The full refactor would be setting `STATUS` by dequeuing the most recently available status from the Status queue in the `MbbsHost` loop, and persisting that for the lifetime of the loop. 

For now -- I think this will work.

Fixes #490 