### PR TITLE
Set ModuleEnabled to TRUE for CLI started module

### DIFF
--- a/MBBSEmu/Program.cs
+++ b/MBBSEmu/Program.cs
@@ -314,7 +314,7 @@ namespace MBBSEmu
                     _menuOptionKey ??= "A";
 
                     //Load Command Line
-                    _moduleConfigurations.Add(new ModuleConfiguration { ModuleIdentifier = _moduleIdentifier, ModulePath = _modulePath, MenuOptionKey = _menuOptionKey });
+                    _moduleConfigurations.Add(new ModuleConfiguration { ModuleIdentifier = _moduleIdentifier, ModulePath = _modulePath, MenuOptionKey = _menuOptionKey, ModuleEnabled = true});
                 }
                 else if (_isModuleConfigFile)
                 {


### PR DESCRIPTION
Modules started via command line `-p` and `-m` had `ModuleEnabled` set to the default bool value of `false`. 

This has been fixed.