### PR TITLE
Enable VT100 Terminal on Windows Console when running external EXE

### DIFF
--- a/MBBSEmu/DOS/ExeRuntime.cs
+++ b/MBBSEmu/DOS/ExeRuntime.cs
@@ -6,15 +6,14 @@ using MBBSEmu.DOS.Interrupts;
 using MBBSEmu.DOS.Structs;
 using MBBSEmu.IO;
 using MBBSEmu.Memory;
-using NLog;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
-using System.Threading;
 using MBBSEmu.Server;
 using MBBSEmu.Session;
+using NLog;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace MBBSEmu.DOS
 {
@@ -121,6 +120,10 @@ namespace MBBSEmu.DOS
 
         public void Run()
         {
+            //Detect if we're on Windows and enable VT100 on the current Terminal Window
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                new Win32VT100().Enable();
+
             while (!Registers.Halt)
                 Cpu.Tick();
 

--- a/MBBSEmu/DOS/ExeRuntime.cs
+++ b/MBBSEmu/DOS/ExeRuntime.cs
@@ -122,7 +122,7 @@ namespace MBBSEmu.DOS
         {
             //Detect if we're on Windows and enable VT100 on the current Terminal Window
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                new Win32VT100().Enable();
+                new Win32VT100(_logger).Enable();
 
             while (!Registers.Halt)
                 Cpu.Tick();

--- a/MBBSEmu/DOS/Win32VT100.cs
+++ b/MBBSEmu/DOS/Win32VT100.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace MBBSEmu.Session.LocalConsole
+namespace MBBSEmu.DOS
 {
     /// <summary>
     ///     Enables VT100 Terminal Emulation with Command Console by calling SetConsoleMode through an external call to the Kernel

--- a/MBBSEmu/Module/MdfFile.cs
+++ b/MBBSEmu/Module/MdfFile.cs
@@ -40,8 +40,8 @@ namespace MBBSEmu.Module
         /// </summary>
         public List<string> Requires { get; set; }
 
-        public List<String> Cleanup { get; set; }
-        public List<String> BBSUp { get; set; }
+        public List<string> Cleanup { get; set; }
+        public List<string> BBSUp { get; set; }
 
         public MdfFile(string mdfFile)
         {
@@ -65,8 +65,8 @@ namespace MBBSEmu.Module
 
         private void Parse()
         {
-            List<String> cleanup = new();
-            List<String> bbsup = new();
+            List<string> cleanup = new();
+            List<string> bbsup = new();
 
             foreach (var line in File.ReadAllLines(_mdfFile))
             {

--- a/MBBSEmu/Session/LocalConsole/LocalConsoleSession.cs
+++ b/MBBSEmu/Session/LocalConsole/LocalConsoleSession.cs
@@ -71,7 +71,7 @@ namespace MBBSEmu.Session.LocalConsole
 
             //Detect if we're on Windows and enable VT100 on the current Terminal Window
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                new Win32VT100().Enable();
+                new Win32VT100(_logger).Enable();
 
             if(disableLogging)
                 (_logger as CustomLogger)?.DisableConsoleLogging();

--- a/MBBSEmu/Session/LocalConsole/LocalConsoleSession.cs
+++ b/MBBSEmu/Session/LocalConsole/LocalConsoleSession.cs
@@ -1,3 +1,4 @@
+using MBBSEmu.DOS;
 using MBBSEmu.HostProcess;
 using MBBSEmu.Logging;
 using MBBSEmu.Session.Enums;


### PR DESCRIPTION
We need to force VT100 mode when running an external EXE (even if not using Local Console Session), so the ANSI output from the EXE being executed is properly handled by the local console and not just written out as a ton of ANSI code text.

Submitting this PR to strike an experimental build -- waiting for reporter of the issue to respond if this fixes it.