### PR TITLE
Input fixes for MMUD

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/cncall_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/cncall_Tests.cs
@@ -21,7 +21,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             Reset();
 
             //Set Input Values
-            var inputLength = (ushort)inputString.Length;
+            var inputLength = (ushort) (inputString.Length - 1);
 
             mbbsModule.Memory.SetArray("INPUT", Encoding.ASCII.GetBytes(inputString));
             mbbsModule.Memory.SetWord("INPLEN", inputLength);

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/endcnc_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/endcnc_Tests.cs
@@ -9,14 +9,13 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
     {
         private const int ENDCNC_ORDINAL = 191;
 
-        [Theory]
-
         //Simple commands with nxtcmd == input
+        [Theory]
         [InlineData("123 ABC\0", 1, 0, "23\0ABC\0", 2)]
         [InlineData("123 ABC\0", 3, 0, "ABC\0", 1)]
         [InlineData("123 ABC\0", 4, 0, "ABC\0", 1)]
         [InlineData("123 ABC\0", 5, 0, "BC\0", 1)]
-        [InlineData("\0", 0, 1, "", 0)]
+        [InlineData("\0", 0, 1, "\0", 0)]
         public void endcnc_Test(string inputString, ushort nxtcmdStartingOffset, char expectedResult, string expectedInputString, ushort expectedMargc)
         {
             //Reset State
@@ -26,7 +25,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             var inputLength = (ushort)inputString.Length;
 
             mbbsModule.Memory.SetArray("INPUT", Encoding.ASCII.GetBytes(inputString));
-            mbbsModule.Memory.SetWord("INPLEN", inputLength);
+            mbbsModule.Memory.SetWord("INPLEN", (ushort) (inputLength - 1));
 
             //Set nxtcmd
             var currentNxtcmd = mbbsEmuMemoryCore.GetPointer("NXTCMD");
@@ -38,7 +37,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Gather Results
             var actualResult = mbbsEmuCpuCore.Registers.AX;
-            var actualInputString = Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetArray("INPUT", mbbsEmuMemoryCore.GetWord("INPLEN")));
+            var actualInputString = Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetArray("INPUT", (ushort) (mbbsEmuMemoryCore.GetWord("INPLEN") + 1)));
             var actualMargc = mbbsEmuMemoryCore.GetWord("MARGC");
             //Verify Results
             Assert.Equal(expectedInputString, actualInputString);

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/rstrin_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/rstrin_Tests.cs
@@ -24,7 +24,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Set Input Values
             mbbsEmuMemoryCore.SetArray("INPUT", Encoding.ASCII.GetBytes(inputCommand));
-            mbbsEmuMemoryCore.SetWord("INPLEN", (ushort)inputCommand.Length);
+            mbbsEmuMemoryCore.SetWord("INPLEN", (ushort) (inputCommand.Length - 1));
 
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, RSTRIN_ORDINAL, new List<FarPtr>());
 

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -859,6 +859,13 @@ namespace MBBSEmu.HostProcess
                         //If BTUCHI Injected a deferred Execution Status, respect that vs. processing the input
                         if (session.GetStatus() == EnumUserStatus.CYCLE)
                         {
+                            //If we're cycling, ignore \r for triggering STTROU and add it to the input buffer for STSROU to handle
+                            if (session.TransparentMode)
+                            {
+                                session.InputBuffer.WriteByte(session.CharacterProcessed);
+                                break;
+                            }
+
                             //Set Status == 3, which means there is a Command Ready
                             session.Status.Clear(); //Clear the 240
                             session.Status.Enqueue(EnumUserStatus.CR_TERMINATED_STRING_AVAILABLE); //Enqueue Status of 3
@@ -868,6 +875,7 @@ namespace MBBSEmu.HostProcess
 
                         //Always Enqueue Input Ready
                         session.Status.Enqueue(EnumUserStatus.CR_TERMINATED_STRING_AVAILABLE);
+
                         break;
                     }
 

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -356,11 +356,9 @@ namespace MBBSEmu.HostProcess
                                 //If the channel has been registered with BEGIN_POLLING
                                 if (session.PollingRoutine != null)
                                 {
+                                    session.Status.Enqueue(EnumUserStatus.POLLING_STATUS);
                                     ProcessPollingRoutine(session);
-
-                                    //Keep the user in Polling Status if the polling routine is still there
-                                    if (session.PollingRoutine != FarPtr.Empty)
-                                        session.Status.Enqueue(EnumUserStatus.POLLING_STATUS);
+                                    session.Status.Dequeue();
                                 }
 
                                 break;
@@ -852,7 +850,7 @@ namespace MBBSEmu.HostProcess
                     }
 
                 //Enter or Return
-                case 0xD when !session.TransparentMode && (session.SessionState != EnumSessionState.InFullScreenDisplay && session.SessionState != EnumSessionState.InFullScreenEditor):
+                case 0xD when (session.SessionState != EnumSessionState.InFullScreenDisplay && session.SessionState != EnumSessionState.InFullScreenEditor):
                     {
                         //If we're in transparent mode or BTUCHI has changed the character to null, don't echo
                         if (!session.TransparentMode && session.CharacterProcessed > 0)

--- a/MBBSEmu/Session/LineBreaker.cs
+++ b/MBBSEmu/Session/LineBreaker.cs
@@ -5,6 +5,8 @@ namespace MBBSEmu.Session
 {
     public class LineBreaker
     {
+        public const byte BACKSPACE = 8;
+        public const byte DELETE = 127;
         public const byte ESCAPE = 0x1B;
         public const int MAX_LINE = 512;
         public const int MAX_OUTPUT_BUFFER = 4096;
@@ -124,7 +126,11 @@ namespace MBBSEmu.Session
                             case ESCAPE: // escape
                                 _parseState = ParseState.ESCAPE;
                                 break;
+                            case DELETE:       // ignore
                             case (byte) '\n':  // ignore
+                                break;
+                            case BACKSPACE:
+                                _lineBufferLength = Math.Max(0, _lineBufferLength - 1);
                                 break;
                             default:
                                 _lineBuffer[_lineBufferLength] = b;


### PR DESCRIPTION
Push polling status & then pop it during poll routine

Ignore TransparentMode when handling \r on input

Fix line break crash related to backspace/deletes

Also fixed INPLEN to not account for extra null character - it was always +1 too large