### PR TITLE
Remove the EZPZ truncation

### DIFF
--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -644,10 +644,6 @@ namespace MBBSEmu.HostProcess.ExportedModules
                                 msFormattedValue.Write(valueCache);
                             }
                         }
-
-                        //Need to truncate -- EZPZ
-                        if (msFormattedValue.Length > stringWidth)
-                            msFormattedValue.SetLength(stringWidth);
                     }
                     msOutput.Write(msFormattedValue.ToArray());
                     continue;


### PR DESCRIPTION
We are truncating instead of just padding. Let's cut that crap out, or stop cutting that crap out.. whatever.

Proofish: https://www.tutorialspoint.com/c_standard_library/c_function_printf.htm

Fixes: https://github.com/mbbsemu/MBBSEmu/issues/498