### PR TITLE
Disable SQLite connection pooling on BTRIEVE connections

### DIFF
--- a/MBBSEmu.Tests/Btrieve/BtrieveFileProcessor_Tests.cs
+++ b/MBBSEmu.Tests/Btrieve/BtrieveFileProcessor_Tests.cs
@@ -155,12 +155,7 @@ namespace MBBSEmu.Tests.Btrieve
 
         private void AssertSqlStructure(string fullPath)
         {
-            var connectionString = new SqliteConnectionStringBuilder()
-            {
-                Mode = SqliteOpenMode.ReadWriteCreate,
-                DataSource = fullPath,
-            }.ToString();
-
+            var connectionString = BtrieveFileProcessor.GetDefaultConnectionStringBuilder(fullPath).ToString();
             using var connection = new SqliteConnection(connectionString);
             connection.Open();
 
@@ -1169,7 +1164,8 @@ namespace MBBSEmu.Tests.Btrieve
         public void CreatesACS()
         {
             var btrieve = new BtrieveFileProcessor();
-            var connectionString = "Data Source=acs.db;Mode=Memory";
+            var connectionString = BtrieveFileProcessor.GetDefaultConnectionStringBuilder("acs.db");
+            connectionString.Mode = SqliteOpenMode.Memory;
 
             btrieve.CreateSqliteDBWithConnectionString(connectionString, CreateACSBtrieveFile());
 
@@ -1188,7 +1184,8 @@ namespace MBBSEmu.Tests.Btrieve
         public void ACSSeekByKey()
         {
             var btrieve = new BtrieveFileProcessor();
-            var connectionString = "Data Source=acs.db;Mode=Memory";
+            var connectionString = BtrieveFileProcessor.GetDefaultConnectionStringBuilder("acs.db");
+            connectionString.Mode = SqliteOpenMode.Memory;
 
             btrieve.CreateSqliteDBWithConnectionString(connectionString, CreateACSBtrieveFile());
 
@@ -1207,7 +1204,8 @@ namespace MBBSEmu.Tests.Btrieve
         public void ACSInsertDuplicateFails()
         {
             var btrieve = new BtrieveFileProcessor();
-            var connectionString = "Data Source=acs.db;Mode=Memory";
+            var connectionString = BtrieveFileProcessor.GetDefaultConnectionStringBuilder("acs.db");
+            connectionString.Mode = SqliteOpenMode.Memory;
 
             btrieve.CreateSqliteDBWithConnectionString(connectionString, CreateACSBtrieveFile());
 
@@ -1236,7 +1234,8 @@ namespace MBBSEmu.Tests.Btrieve
         public void KeylessDatabaseEnumeration()
         {
             var btrieve = new BtrieveFileProcessor();
-            var connectionString = "Data Source=acs.db;Mode=Memory";
+            var connectionString = BtrieveFileProcessor.GetDefaultConnectionStringBuilder("acs.db");
+            connectionString.Mode = SqliteOpenMode.Memory;
 
             btrieve.CreateSqliteDBWithConnectionString(connectionString, CreateKeylessBtrieveFile());
 
@@ -1266,7 +1265,8 @@ namespace MBBSEmu.Tests.Btrieve
         public void KeylessDataQueryFails()
         {
             var btrieve = new BtrieveFileProcessor();
-            var connectionString = "Data Source=acs.db;Mode=Memory";
+            var connectionString = BtrieveFileProcessor.GetDefaultConnectionStringBuilder("acs.db");
+            connectionString.Mode = SqliteOpenMode.Memory;
 
             btrieve.CreateSqliteDBWithConnectionString(connectionString, CreateKeylessBtrieveFile());
 

--- a/MBBSEmu.Tests/ExportedModules/ExportedModuleTestBase.cs
+++ b/MBBSEmu.Tests/ExportedModules/ExportedModuleTestBase.cs
@@ -11,6 +11,7 @@ using MBBSEmu.Memory;
 using MBBSEmu.Module;
 using MBBSEmu.Session;
 using MBBSEmu.TextVariables;
+using Microsoft.Data.Sqlite;
 using NLog;
 using System;
 using System.Collections.Generic;
@@ -290,7 +291,8 @@ namespace MBBSEmu.Tests.ExportedModules
         protected void AllocateBB(BtrieveFile btrieveFile, ushort maxRecordLength)
         {
             var btrieve = new BtrieveFileProcessor() { FullPath = Path.Combine(mbbsModule.ModulePath, btrieveFile.FileName) };
-            var connectionString = "Data Source=acs.db;Mode=Memory";
+            var connectionString = BtrieveFileProcessor.GetDefaultConnectionStringBuilder("acs.db");
+            connectionString.Mode = SqliteOpenMode.Memory;
 
             btrieve.CreateSqliteDBWithConnectionString(connectionString, btrieveFile);
             majorbbs.AllocateBB(btrieve, maxRecordLength, Path.GetFileName(btrieve.FullPath));

--- a/MBBSEmu/Btrieve/BtrieveFileProcessor.cs
+++ b/MBBSEmu/Btrieve/BtrieveFileProcessor.cs
@@ -201,13 +201,7 @@ namespace MBBSEmu.Btrieve
 
             FullPath = fullPath;
 
-            var connectionString = new Microsoft.Data.Sqlite.SqliteConnectionStringBuilder()
-            {
-                Mode = Microsoft.Data.Sqlite.SqliteOpenMode.ReadWriteCreate,
-                DataSource = fullPath,
-            }.ToString();
-
-            Connection = new SqliteConnection(connectionString);
+            Connection = new SqliteConnection(GetDefaultConnectionStringBuilder(fullPath).ToString());
             Connection.Open();
 
             LoadSqliteMetadata();
@@ -1145,16 +1139,13 @@ namespace MBBSEmu.Btrieve
 
             FullPath = fullpath;
 
-            var connectionString = new Microsoft.Data.Sqlite.SqliteConnectionStringBuilder()
-            {
-                Mode = Microsoft.Data.Sqlite.SqliteOpenMode.ReadWriteCreate,
-                DataSource = fullpath,
-            }.ToString();
-
-            CreateSqliteDBWithConnectionString(connectionString, btrieveFile);
+            CreateSqliteDBWithConnectionString(GetDefaultConnectionStringBuilder(fullpath), btrieveFile);
         }
 
-        public void CreateSqliteDBWithConnectionString(string connectionString, BtrieveFile btrieveFile)
+        public void CreateSqliteDBWithConnectionString(SqliteConnectionStringBuilder connectionString, BtrieveFile btrieveFile) =>
+            CreateSqliteDBWithConnectionString(connectionString.ToString(), btrieveFile);
+
+        private void CreateSqliteDBWithConnectionString(string connectionString, BtrieveFile btrieveFile)
         {
             Connection = new SqliteConnection(connectionString);
             Connection.Open();
@@ -1183,5 +1174,12 @@ namespace MBBSEmu.Btrieve
             cmd.Parameters.Clear();
             return cmd;
         }
+
+        public static SqliteConnectionStringBuilder GetDefaultConnectionStringBuilder(string filepath) => new Microsoft.Data.Sqlite.SqliteConnectionStringBuilder()
+            {
+                Mode = Microsoft.Data.Sqlite.SqliteOpenMode.ReadWriteCreate,
+                DataSource = filepath,
+                Pooling = false,
+            };
     }
 }

--- a/MBBSEmu/DOS/Interrupts/Int7Bh.cs
+++ b/MBBSEmu/DOS/Interrupts/Int7Bh.cs
@@ -1,4 +1,3 @@
-
 using MBBSEmu.Btrieve;
 using MBBSEmu.Btrieve.Enums;
 using MBBSEmu.CPU;


### PR DESCRIPTION
Otherwise MMUD cleanup utility won't run since it reuses a pooled connection thinking the old DB was actually deleted