### PR TITLE
Soft patch enhancement

### DIFF
--- a/MBBSEmu.Tests/Converters/JsonFarPtrConverter_Tests.cs
+++ b/MBBSEmu.Tests/Converters/JsonFarPtrConverter_Tests.cs
@@ -1,0 +1,48 @@
+﻿using MBBSEmu.Converters;
+using MBBSEmu.Memory;
+using System.Text.Json;
+using Xunit;
+
+namespace MBBSEmu.Tests.Converters
+{
+    public class JsonFarPtrConverter_Tests
+    {
+        internal class TestResult
+        {
+            public FarPtr TestValue { get; set; }
+        }
+
+        [Theory]
+        [InlineData("0001:0001", 1, 1, false)]
+        [InlineData("FFFF:FFFF", ushort.MaxValue, ushort.MaxValue, false)]
+        [InlineData("FFFF:0001", ushort.MaxValue, 1, false)]
+        [InlineData("0000:FFFF", 0, ushort.MaxValue, false)]
+        [InlineData("XXXX:FFFF", 0, ushort.MaxValue, true)]
+        [InlineData("FFFF:XXXX", 0, ushort.MaxValue, true)]
+        [InlineData("FFFFF:FFFFF", 0, 0, true)]
+        [InlineData("", 0, 0, true)]
+        [InlineData("X:X", 0, 0, true)]
+        [InlineData("X:X:X", 0, 0, true)]
+        public void StringToFarPtrTest(string farPtrString, ushort segment, ushort offset, bool throwsException)
+        {
+            var jsonToDeserialize = $"{{ \"TestValue\" : \"{farPtrString}\" }}";
+
+            var options = new JsonSerializerOptions
+            {
+                Converters = { new JsonFarPtrConverter() }
+            };
+
+            if (!throwsException)
+            {
+                var actualResult = JsonSerializer.Deserialize<TestResult>(jsonToDeserialize, options);
+                Assert.Equal(segment, actualResult.TestValue.Segment);
+                Assert.Equal(offset, actualResult.TestValue.Offset);
+            }
+            else
+            {
+                Assert.Throws<JsonException>(() =>
+                    JsonSerializer.Deserialize<JsonBooleanConverter_Tests.TestResult>(jsonToDeserialize, options));
+            }
+        }
+    }
+}

--- a/MBBSEmu/Converters/JsonFarPtrConverter.cs
+++ b/MBBSEmu/Converters/JsonFarPtrConverter.cs
@@ -1,0 +1,31 @@
+﻿using MBBSEmu.Memory;
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MBBSEmu.Converters
+{
+    public class JsonFarPtrConverter : JsonConverter<FarPtr>
+    {
+        public override FarPtr Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.String:
+                {
+                    var value = reader.GetString();
+
+                    if (value == null)
+                        throw new JsonException();
+
+                    return new FarPtr(value);
+                }
+
+                default:
+                    throw new ArgumentException($"Invalid JsonToken Type: {reader.TokenType}");
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, FarPtr value, JsonSerializerOptions options) => writer.WriteStringValue(value.ToString());
+    }
+}

--- a/MBBSEmu/Disassembler/NEFile.cs
+++ b/MBBSEmu/Disassembler/NEFile.cs
@@ -1,9 +1,10 @@
+using MBBSEmu.Disassembler.Artifacts;
+using MBBSEmu.Util;
 using NLog;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using MBBSEmu.Disassembler.Artifacts;
 
 namespace MBBSEmu.Disassembler
 {
@@ -30,12 +31,18 @@ namespace MBBSEmu.Disassembler
         public List<Entry> EntryTable;
         public List<NonResidentName> NonResidentNameTable;
 
+        /// <summary>
+        ///  SHA256 Hash of the Loaded File
+        /// </summary>
+        public string CRC32 { get; set; }
+
         private ILogger _logger;
 
         public NEFile(ILogger logger, string fullFilePath, ReadOnlySpan<byte> data)
         {
             _logger = logger;
             FileContent = data.ToArray();
+            CRC32 = BitConverter.ToString(new Crc32().ComputeHash(FileContent)).Replace("-", string.Empty);
             var f = new FileInfo(fullFilePath);
             Path = f.DirectoryName + System.IO.Path.DirectorySeparatorChar;
             FileName = f.Name;

--- a/MBBSEmu/Disassembler/NEFile.cs
+++ b/MBBSEmu/Disassembler/NEFile.cs
@@ -32,7 +32,7 @@ namespace MBBSEmu.Disassembler
         public List<NonResidentName> NonResidentNameTable;
 
         /// <summary>
-        ///  SHA256 Hash of the Loaded File
+        ///  CRC32 of the Loaded File
         /// </summary>
         public string CRC32 { get; set; }
 

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -953,6 +953,7 @@ namespace MBBSEmu.HostProcess
         public void AddModule(MbbsModule module)
         {
             Logger.Info($"({module.ModuleIdentifier}) Adding Module...");
+            Logger.Info($"({module.ModuleIdentifier}) CRC32: {module.MainModuleDll.File.CRC32}");
 
             //Setup Exported Modules
             module.ExportedModuleDictionary.Add(Majorbbs.Segment, GetFunctions(module, "MAJORBBS"));

--- a/MBBSEmu/Memory/FarPtr.cs
+++ b/MBBSEmu/Memory/FarPtr.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace MBBSEmu.Memory
 {
@@ -44,6 +45,19 @@ namespace MBBSEmu.Memory
         {
             Segment = pointer.Segment;
             Offset = pointer.Offset;
+        }
+
+        public FarPtr(string pointer)
+        {
+            var splitPointer = pointer.Split(':');
+
+            if (splitPointer.Length != 2
+                || !ushort.TryParse(splitPointer[0], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var parsedSegment)
+                || !ushort.TryParse(splitPointer[1], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var parsedOffset))
+                throw new ArgumentException($"Invalid Pointer String: {pointer}");
+
+            Segment = parsedSegment;
+            Offset = parsedOffset;
         }
 
         public void FromSpan(ReadOnlySpan<byte> farPtrSpan)

--- a/MBBSEmu/Module/MBBSModule.cs
+++ b/MBBSEmu/Module/MBBSModule.cs
@@ -310,7 +310,7 @@ namespace MBBSEmu.Module
         private void LoadModuleDll(string dllToLoad)
         {
             var requiredDll = new MbbsDll(_fileUtility, _logger);
-            if (!requiredDll.Load(dllToLoad, ModulePath, ModuleConfig.Patches?.Where(x => x.AbsoluteOffset > 0).ToList()))
+            if (!requiredDll.Load(dllToLoad, ModulePath, ModuleConfig.Patches))
             {
                 _logger.Error($"Unable to load {dllToLoad}");
                 return;

--- a/MBBSEmu/Module/MbbsDll.cs
+++ b/MBBSEmu/Module/MbbsDll.cs
@@ -69,7 +69,7 @@ namespace MBBSEmu.Module
             //We perform Absolute Patching here as this is the last stop before the data is loaded into the NE file and split into Segments
             if (modulePatches != null)
             {
-                foreach (var p in modulePatches.Where(x => x?.AbsoluteOffset > 0))
+                foreach (var p in modulePatches.Where(x => (bool)x?.Enabled && x.AbsoluteOffset > 0))
                 {
                     if (string.Compare(p.CRC32, fileCRC32, StringComparison.InvariantCultureIgnoreCase) != 0)
                     {
@@ -89,7 +89,7 @@ namespace MBBSEmu.Module
             //Address Patching
             if (modulePatches != null)
             {
-                foreach (var p in modulePatches.Where(x => x.Addresses.Count > 0 || x.Address != null))
+                foreach (var p in modulePatches.Where(x => (bool)x?.Enabled && (x.Addresses.Count > 0 || x.Address != null)))
                 {
                     if (string.Compare(p.CRC32, fileCRC32, StringComparison.InvariantCultureIgnoreCase) != 0)
                     {

--- a/MBBSEmu/Module/MbbsDll.cs
+++ b/MBBSEmu/Module/MbbsDll.cs
@@ -89,16 +89,13 @@ namespace MBBSEmu.Module
             //Address Patching
             if (modulePatches != null)
             {
-                foreach (var p in modulePatches.Where(x => (bool)x?.Enabled && (x.Addresses.Count > 0 || x.Address != null)))
+                foreach (var p in modulePatches.Where(x => (bool)x?.Enabled && x.Addresses.Count > 0))
                 {
                     if (string.Compare(p.CRC32, fileCRC32, StringComparison.InvariantCultureIgnoreCase) != 0)
                     {
                         _logger.Error($"Unable to apply patch {p.Name}: Module CRC32 Mismatch (Expected: {p.CRC32}, Actual: {fileCRC32})");
                         continue;
                     }
-
-                    if (p.Address != null && p.Addresses == null)
-                        p.Addresses = new List<FarPtr>() { p.Address };
 
                     foreach (var a in p.Addresses)
                     {

--- a/MBBSEmu/Module/ModulePatch.cs
+++ b/MBBSEmu/Module/ModulePatch.cs
@@ -21,6 +21,7 @@ namespace MBBSEmu.Module
         public uint AbsoluteOffset { get; set; }
         public EnumModulePatchType PatchType { get; set; }
         public string Patch { get; set; }
+        public string CRC32 { get; set; }
 
         /// <summary>
         ///     Returns bytes for the patch depending on the Patch Type

--- a/MBBSEmu/Module/ModulePatch.cs
+++ b/MBBSEmu/Module/ModulePatch.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using MBBSEmu.Memory;
+using System;
+using System.Collections.Generic;
 using System.Text;
-using System.Text.Json.Serialization;
 
 namespace MBBSEmu.Module
 {
@@ -15,8 +16,8 @@ namespace MBBSEmu.Module
 
         public string Name { get; set; }
         public string Description { get; set; }
-        public ushort Segment { get; set; }
-        public ushort Offset { get; set; }
+        public List<FarPtr> Addresses { get; set; }
+        public FarPtr Address { get; set; }
         public uint AbsoluteOffset { get; set; }
         public EnumModulePatchType PatchType { get; set; }
         public string Patch { get; set; }

--- a/MBBSEmu/Module/ModulePatch.cs
+++ b/MBBSEmu/Module/ModulePatch.cs
@@ -17,7 +17,6 @@ namespace MBBSEmu.Module
         public string Name { get; set; }
         public string Description { get; set; }
         public List<FarPtr> Addresses { get; set; }
-        public FarPtr Address { get; set; }
         public uint AbsoluteOffset { get; set; }
         public EnumModulePatchType PatchType { get; set; }
         public string Patch { get; set; }

--- a/MBBSEmu/Module/ModulePatch.cs
+++ b/MBBSEmu/Module/ModulePatch.cs
@@ -22,6 +22,12 @@ namespace MBBSEmu.Module
         public EnumModulePatchType PatchType { get; set; }
         public string Patch { get; set; }
         public string CRC32 { get; set; }
+        private bool? _enabled;
+        public bool? Enabled
+        {
+            get => _enabled ?? true;
+            set => _enabled = value;
+        }
 
         /// <summary>
         ///     Returns bytes for the patch depending on the Patch Type

--- a/MBBSEmu/Program.cs
+++ b/MBBSEmu/Program.cs
@@ -327,8 +327,8 @@ namespace MBBSEmu
                     {
                         Converters = {
                             new JsonBooleanConverter(),
-                            new JsonStringEnumConverter()
-                            
+                            new JsonStringEnumConverter(),
+                            new JsonFarPtrConverter()
                         }
                     };
 

--- a/MBBSEmu/Util/CRC32.cs
+++ b/MBBSEmu/Util/CRC32.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) Damien Guard.  All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. 
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+using System;
+using System.Security.Cryptography;
+
+namespace MBBSEmu.Util
+{
+    /// <summary>
+    /// Implements a 32-bit CRC hash algorithm compatible with Zip etc.
+    /// </summary>
+    /// <remarks>
+    /// Crc32 should only be used for backward compatibility with older file formats
+    /// and algorithms. It is not secure enough for new applications.
+    /// If you need to call multiple times for the same data either use the HashAlgorithm
+    /// interface or remember that the result of one Compute call needs to be ~ (XOR) before
+    /// being passed in as the seed for the next Compute call.
+    /// </remarks>
+    public sealed class Crc32 : HashAlgorithm
+    {
+        private const uint DefaultPolynomial = 0xedb88320u;
+        private const uint DefaultSeed = 0xffffffffu;
+
+        private static uint[] defaultTable;
+
+        private readonly uint _seed;
+        private readonly uint[] _table;
+        private uint _hash;
+
+        public Crc32()
+            : this(DefaultPolynomial, DefaultSeed)
+        {
+        }
+
+        public Crc32(uint polynomial, uint seed)
+        {
+            if (!BitConverter.IsLittleEndian)
+                throw new PlatformNotSupportedException("Not supported on Big Endian processors");
+
+            _table = InitializeTable(polynomial);
+            _seed = _hash = seed;
+        }
+
+        public override void Initialize()
+        {
+            _hash = _seed;
+        }
+
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            _hash = CalculateHash(_table, _hash, array, ibStart, cbSize);
+        }
+
+        protected override byte[] HashFinal()
+        {
+            var hashBuffer = UInt32ToBigEndianBytes(~_hash);
+            HashValue = hashBuffer;
+            return hashBuffer;
+        }
+
+        public override int HashSize => 32;
+
+        public static uint Compute(ReadOnlySpan<byte> buffer)
+        {
+            return Compute(DefaultSeed, buffer);
+        }
+
+        public static uint Compute(uint seed, ReadOnlySpan<byte> buffer)
+        {
+            return Compute(DefaultPolynomial, seed, buffer);
+        }
+
+        public static uint Compute(uint polynomial, uint seed, ReadOnlySpan<byte> buffer)
+        {
+            return ~CalculateHash(InitializeTable(polynomial), seed, buffer, 0, buffer.Length);
+        }
+
+        static uint[] InitializeTable(uint polynomial)
+        {
+            if (polynomial == DefaultPolynomial && defaultTable != null)
+                return defaultTable;
+
+            var createTable = new uint[256];
+            for (var i = 0; i < 256; i++)
+            {
+                var entry = (uint)i;
+                for (var j = 0; j < 8; j++)
+                    if ((entry & 1) == 1)
+                        entry = (entry >> 1) ^ polynomial;
+                    else
+                        entry >>= 1;
+                createTable[i] = entry;
+            }
+
+            if (polynomial == DefaultPolynomial)
+                defaultTable = createTable;
+
+            return createTable;
+        }
+
+        static uint CalculateHash(uint[] table, uint seed, ReadOnlySpan<byte> buffer, int start, int size)
+        {
+            var hash = seed;
+            for (var i = start; i < start + size; i++)
+                hash = (hash >> 8) ^ table[buffer[i] ^ hash & 0xff];
+            return hash;
+        }
+
+        static byte[] UInt32ToBigEndianBytes(uint uint32)
+        {
+            var result = BitConverter.GetBytes(uint32);
+
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(result);
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
- Add FarPtr Converter for JSON
- Add `Address` and `Addresses` to specify SEG:OFF for patch locations
- Added constructor to FarPtr that takes `SEG:OFF` string
- Added CRC32 calculation on Module and verification of CRC32 on Patches (to ensure correct version is being patched)
- Prints CRC32 of Module Loaded on Startup
- Added `Enabled` as an option on Patches so they can be easily enabled/disabled without having to delete them from the file