### PR TITLE
Fix a Race Condition if a disconnect were to happen during processing…

### DIFF
--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -681,7 +681,11 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             var txtvarsFound = _textVariableService.ExtractVariableDefinitions(outputBuffer);
 
-            var txtvarDictionary = ChannelDictionary[ChannelNumber].SessionVariables;
+            //This can happen if a channel disconnects during the processing of the main loop
+            if (!ChannelDictionary.TryGetValue(ChannelNumber, out var channelSession))
+                return outputBuffer;
+
+            var txtvarDictionary = channelSession.SessionVariables;
 
             //Get Their Values
             var txtvarMemoryBase = Module.Memory.GetVariablePointer("TXTVARS");


### PR DESCRIPTION
Fixes Discord Issue where a disconnect can trigger a race condition when trying to read the Text Variables defined on a channel during the main process loop.

```
mbbsemu    | 2022-03-14 15:58:50.2780 Warn MBBSEmu.Session.SocketSession.CloseSocket Session 10.80.0.152:50434 (Channel: 0) Client disconnected
mbbsemu    | 2022-03-14 15:58:50.3367 Info MBBSEmu.HostProcess.MbbsHost.RemoveSession Removing Channel: 0
mbbsemu    | Unhandled exception. System.Collections.Generic.KeyNotFoundException: The given key '0' was not present in the dictionary.
mbbsemu    |    at System.Collections.Generic.Dictionary`2.get_Item(TKey )
mbbsemu    |    at MBBSEmu.HostProcess.ExportedModules.ExportedModuleBase.ProcessTextVariables(ReadOnlySpan`1 outputBuffer)
mbbsemu    |    at MBBSEmu.HostProcess.ExportedModules.ExportedModuleBase.FormatOutput(ReadOnlySpan`1 outputBytes)
mbbsemu    |    at MBBSEmu.HostProcess.ExportedModules.Galgsbl.btuxmt()
mbbsemu    |    at MBBSEmu.HostProcess.ExportedModules.Galgsbl.Invoke(UInt16 ordinal, Boolean offsetsOnly)
mbbsemu    |    at MBBSEmu.HostProcess.ExecutionUnits.ExecutionUnit.ExternalFunctionDelegate(UInt16 ordinal, UInt16 functionOrdinal)
mbbsemu    |    at MBBSEmu.CPU.CpuCore.Op_Call()
mbbsemu    |    at MBBSEmu.CPU.CpuCore.Tick()
mbbsemu    |    at MBBSEmu.HostProcess.ExecutionUnits.ExecutionUnit.Execute(FarPtr entryPoint, UInt16 channelNumber, Boolean simulateCallFar, Boolean bypassState, Queue`1 initialStackValues, UInt16 initialStackPointer)
mbbsemu    |    at MBBSEmu.Module.MbbsModule.Execute(FarPtr entryPoint, UInt16 channelNumber, Boolean simulateCallFar, Boolean bypassSetState, Queue`1 initialStackValues, UInt16 initialStackPointer)
mbbsemu    |    at MBBSEmu.HostProcess.MbbsHost.WorkerThread()
mbbsemu    |    at System.Threading.Thread.StartCallback()
```