### PR TITLE
Do not increment UsrPtr.Substt when exiting FSD.

### DIFF
--- a/MBBSEmu/HostProcess/HostRoutines/FsdRoutines.cs
+++ b/MBBSEmu/HostProcess/HostRoutines/FsdRoutines.cs
@@ -725,7 +725,6 @@ namespace MBBSEmu.HostProcess.HostRoutines
             //Invokes STT on exit
             session.SessionState = EnumSessionState.InModule;
             session.Status.Enqueue(EnumUserStatus.CR_TERMINATED_STRING_AVAILABLE);
-            session.UsrPtr.Substt++;
         }
 
         /// <summary>


### PR DESCRIPTION
This line of code was preventing the FSD from returning control to the user when exiting the Majormud character editor.

After conversation on Github and Discord, we determined this code was putting the system into a bad state.

We are not aware of any other modules and/or FSDs that require this code, so we feel confident removing it.