### PR TITLE
Add Key Pause before Exit

### DIFF
--- a/MBBSEmu/Program.cs
+++ b/MBBSEmu/Program.cs
@@ -160,6 +160,8 @@ namespace MBBSEmu
                         case "-?":
                             Console.WriteLine(new ResourceManager().GetString("MBBSEmu.Assets.commandLineHelp.txt"));
                             Console.WriteLine($"Version: {new ResourceManager().GetString("MBBSEmu.Assets.version.txt")}");
+                            Console.WriteLine("(Press Any Key to Exit)");
+                            Console.ReadKey();
                             return;
                         case "-CONFIG":
                         case "-C":


### PR DESCRIPTION
- Prevents window from closing instantly on Windows for people who double-click on the EXE