### PR TITLE
Update RNG to use Borland C++ RNG Routine

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/rand_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/rand_Tests.cs
@@ -11,17 +11,17 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         private const int RAND_ORDINAL = 486;
 
         [Theory]
-        [InlineData(1234, 1356)]
-        [InlineData(2236414843, 29133)]
-        [InlineData(4056779384, 21998)]
-        [InlineData(3589159641, 27018)]
-        [InlineData(1770671342, 30398)]
-        [InlineData(4139675975, 13799)]
-        [InlineData(904336820, 26300)]
-        [InlineData(3871102533, 16520)]
-        [InlineData(3230196298, 26957)]
-        [InlineData(1766679891, 21523)]
-        public void srandTest(uint seed, ushort expectedRandom)
+        [InlineData(1234, 1356, 2236414843)]
+        [InlineData(2236414843, 29133, 4056779384)]
+        [InlineData(4056779384, 21998, 3589159641)]
+        [InlineData(3589159641, 27018, 1770671342)]
+        [InlineData(1770671342, 30398, 4139675975)]
+        [InlineData(4139675975, 13799, 904336820)]
+        [InlineData(904336820, 26300, 3871102533)]
+        [InlineData(3871102533, 16520, 3230196298)]
+        [InlineData(3230196298, 26957, 1766679891)]
+        [InlineData(1766679891, 21523, 1410548784)]
+        public void srandTest(uint seed, ushort expectedRandom, uint newSeed)
         {
             Reset();
 
@@ -31,6 +31,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Verify Results
             Assert.Equal(expectedRandom, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(newSeed, mbbsEmuMemoryCore.GetDWord("RANDSEED"));
         }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/rand_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/rand_Tests.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    /// <summary>
+    ///     Tests verified against results from Borland C++ 4.5 for DOS
+    /// </summary>
+    public class rand_Tests : ExportedModuleTestBase
+    {
+        private const int RAND_ORDINAL = 486;
+
+        [Theory]
+        [InlineData(1234, 1356)]
+        [InlineData(2236414843, 29133)]
+        [InlineData(4056779384, 21998)]
+        [InlineData(3589159641, 27018)]
+        [InlineData(1770671342, 30398)]
+        [InlineData(4139675975, 13799)]
+        [InlineData(904336820, 26300)]
+        [InlineData(3871102533, 16520)]
+        [InlineData(3230196298, 26957)]
+        [InlineData(1766679891, 21523)]
+        public void srandTest(uint seed, ushort expectedRandom)
+        {
+            Reset();
+
+            mbbsEmuMemoryCore.SetDWord("RANDSEED", seed);
+            
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, RAND_ORDINAL, new List<ushort>());
+
+            //Verify Results
+            Assert.Equal(expectedRandom, mbbsEmuCpuRegisters.AX);
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/random_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/random_Tests.cs
@@ -69,16 +69,5 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             //Verify Results
             Assert.Equal(mbbsEmuCpuRegisters.GetLong(), expectedValue);
         }
-
-        [Fact]
-        public void randTest()
-        {
-            Reset();
-
-            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment,RAND_ORDINAL, new List<ushort>());
-
-            //Verify Results
-            Assert.InRange(mbbsEmuCpuRegisters.AX, 1, 32767);
-        }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/srand_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/srand_Tests.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class srand_Tests : ExportedModuleTestBase
+    {
+        private const int SRAND_ORDINAL = 561;
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(ushort.MaxValue)]
+        public void srandTest(ushort seed)
+        {
+            Reset();
+
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, SRAND_ORDINAL, new List<ushort> { seed });
+
+            //Verify Results
+            Assert.Equal(seed, mbbsEmuMemoryCore.GetDWord("RANDSEED"));
+        }
+    }
+}

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -230,6 +230,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             Module.Memory.SetArray("TXTVARS", new TextvarStruct("SYSTEM", new FarPtr(Segment, 9000)).Data); //Set 1st var as SYSTEM variable reference with special pointer
             Module.Memory.AllocateVariable("HDLCON", FarPtr.Size); //Handles the connection for the current User
             Module.Memory.AllocateVariable("RANDSEED", sizeof(uint)); //Seed value for Borland C++ Pseudo-Random Number Generator
+            Module.Memory.SetDWord("RANDSEED", (uint)_random.Next(1, ushort.MaxValue)); //Seed RNG with a random value
 
             _tfsState = Module.Memory.AllocateVariable("TFSTATE", sizeof(ushort));
             _tfspst = Module.Memory.AllocateVariable("TFSPST", FarPtr.Size);

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -8346,7 +8346,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///     While the seed stored in memory is a 32-bit long, only the lower 16-bits are set
         ///     via the srand() method. The high 16-bits are always set to zero.
         ///
-        ///     Signature: void srabd(int seed)
+        ///     Signature: void srand(int seed)
         /// </summary>
         private void srand()
         {


### PR DESCRIPTION
- Update `srand()` to set seed in memory
- Change `rand()` from using internal C# RNG to ported Borland C++ routine