### PR TITLE
Print warning messages before cleanup runs.

### DIFF
--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -155,8 +155,12 @@ namespace MBBSEmu.HostProcess
             _exportedFunctions = new Dictionary<string, IExportedModule>();
             _realTimeStopwatch = Stopwatch.StartNew();
             _incomingSessions = new Queue<SessionBase>();
+
+            //Setup Cleanup Restart Event
             _cleanupTime = _configuration.CleanupTime;
-            _cleanupTimer = new Timer(_ => _performCleanup = true, this, NowUntil(_cleanupTime), TimeSpan.FromDays(1));
+            _cleanupTimer = new Timer(_ => _performCleanup = true, null, NowUntil(_cleanupTime), TimeSpan.FromDays(1));
+            Logger.Info($"Waiting {NowUntil(_cleanupTime)} until {_cleanupTime} to perform Nightly Cleanup");
+
             _cleanupWarningTimer = SetupCleanupWarningTimer();
 
             if (_configuration.TimerHertz > 0)
@@ -1398,15 +1402,19 @@ namespace MBBSEmu.HostProcess
             Start(moduleConfigurations);
         }
 
+        /// <summary>
+        ///     Returns a TimeSpan representing the time between now and the specified time.
+        /// </summary>
+        /// <param name="timeOfDay">24-hour timespan representing a time of day, and determining the time between now and the time specified</param>
+        /// <returns></returns>
         private TimeSpan NowUntil(TimeSpan timeOfDay)
         {
-            var waitTime = _cleanupTime - Clock.Now.TimeOfDay;
+            var waitTime = timeOfDay - Clock.Now.TimeOfDay;
             if (waitTime < TimeSpan.Zero)
             {
                 waitTime += TimeSpan.FromDays(1);
             }
 
-            Logger.Info($"Waiting {waitTime} until {timeOfDay} to perform nightly cleanup");
             return waitTime;
         }
 

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -228,7 +228,7 @@ namespace MBBSEmu.HostProcess
         public void Stop()
         {
             _isRunning = false;
-            _cleanupTimer.Dispose();
+            _cleanupTimer?.Dispose();
             _cleanupWarningTimer?.Dispose();
             _tickTimer?.Dispose();
             // this set must come after _isRunning is set to false, to trigger the exit of the

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -159,7 +159,7 @@ namespace MBBSEmu.HostProcess
             //Setup Cleanup Restart Event
             _cleanupTime = _configuration.CleanupTime;
             _cleanupTimer = new Timer(_ => _performCleanup = true, null, NowUntil(_cleanupTime), TimeSpan.FromDays(1));
-            Logger.Info($"Waiting {NowUntil(_cleanupTime)} until {_cleanupTime} to perform Nightly Cleanup");
+            Logger.Error($"Waiting {NowUntil(_cleanupTime)} until {_cleanupTime} to perform Nightly Cleanup");
 
             _cleanupWarningTimer = SetupCleanupWarningTimer();
 
@@ -1315,6 +1315,10 @@ namespace MBBSEmu.HostProcess
             var initialWarningTime = _cleanupTime - TimeSpan.FromMinutes(CleanupWarningInitialMinutes);
             var dueTime = (int) NowUntil(initialWarningTime).TotalMilliseconds;
             var period = (int) TimeSpan.FromMinutes(1).TotalMilliseconds;
+
+            Logger.Error($"initialWarningTime: {initialWarningTime.Minutes}");
+            Logger.Error($"dueTime: {NowUntil(initialWarningTime).Minutes}");
+            Logger.Error($"period: {TimeSpan.FromMinutes(1).Minutes}");
 
             return new Timer(SendCleanupWarning, null, dueTime, period);
         }

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -1338,7 +1338,7 @@ namespace MBBSEmu.HostProcess
                     var channel = c.Value.Channel;
 
                     Logger.Error($"Sending cleanup warning to channel {channel}: {_cleanupWarningMinutesRemaining} {minuteText} until shutdown.");
-                    _channelDictionary[channel].SendToClient($"|RESET|\r\n|B||RED|Sorry to interrupt here, but the server will be shutting down in {_cleanupWarningMinutesRemaining} {minuteText}. Please finish up and log off.|RESET|\r\n".EncodeToANSIArray());
+                    _channelDictionary[channel].SendToClient($"|RESET|\r\n|B||MAGENTA|Sorry to interrupt here, but the server will be shutting down in {_cleanupWarningMinutesRemaining} {minuteText}. Please finish up and log off.|RESET|\r\n".EncodeToANSIArray());
                 }
                 _cleanupWarningMinutesRemaining--;
                 Logger.Error($"finished SendCleanupWarning");

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -1311,14 +1311,12 @@ namespace MBBSEmu.HostProcess
         private Timer SetupCleanupWarningTimer()
         {
             _cleanupWarningMinutesRemaining = CleanupWarningInitialMinutes;
-            var initialWarningTime = _cleanupTime - TimeSpan.FromMinutes(CleanupWarningInitialMinutes);
 
-            return new Timer(
-                SendCleanupWarning,
-                null,
-                (int) NowUntil(initialWarningTime).TotalMilliseconds,
-                (int) TimeSpan.FromMinutes(1).TotalMilliseconds
-            );
+            var initialWarningTime = _cleanupTime - TimeSpan.FromMinutes(CleanupWarningInitialMinutes);
+            var dueTime = (int) NowUntil(initialWarningTime).TotalMilliseconds;
+            var period = (int) TimeSpan.FromMinutes(1).TotalMilliseconds;
+
+            return new Timer(SendCleanupWarning, null, dueTime, period);
         }
 
         private void SendCleanupWarning(object _)

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -166,9 +166,6 @@ namespace MBBSEmu.HostProcess
             //Setup Cleanup Restart Event
             _cleanupTime = _configuration.CleanupTime;
             _cleanupTimer = new Timer(_ => _performCleanup = true, null, NowUntil(_cleanupTime + _cleanupGracePeriod), TimeSpan.FromDays(1));
-
-            Logger.Error($"Waiting {NowUntil(_cleanupTime)} until {_cleanupTime} to perform Nightly Cleanup");
-
             _cleanupWarningTimer = SetupCleanupWarningTimer();
 
             if (_configuration.TimerHertz > 0)
@@ -1321,26 +1318,24 @@ namespace MBBSEmu.HostProcess
             _cleanupWarningMinutesRemaining = CleanupWarningInitialMinutes;
 
             var initialWarningTime = _cleanupTime + _cleanupGracePeriod - TimeSpan.FromMinutes(CleanupWarningInitialMinutes);
-            var dueTime = (int) NowUntil(initialWarningTime).TotalMilliseconds;
-            var period = (int) TimeSpan.FromMinutes(1).TotalMilliseconds;
+            var dueTime = NowUntil(initialWarningTime);
+            var period = TimeSpan.FromMinutes(1);
 
-            Logger.Error($"_cleanupTime Hours: {_cleanupTime.Hours}");
-            Logger.Error($"_cleanupTime Minutes: {_cleanupTime.Minutes}");
-            Logger.Error($"initialWarningTime Hours: {initialWarningTime.Hours}");
-            Logger.Error($"initialWarningTime Minutes: {initialWarningTime.Minutes}");
-            Logger.Error($"dueTime: {NowUntil(initialWarningTime).Minutes}");
-            Logger.Error($"period: {TimeSpan.FromMinutes(1).Minutes}");
+            Logger.Debug($"_cleanupTime Hours: {_cleanupTime.Hours}");
+            Logger.Debug($"_cleanupTime Minutes: {_cleanupTime.Minutes}");
+            Logger.Debug($"initialWarningTime Hours: {initialWarningTime.Hours}");
+            Logger.Debug($"initialWarningTime Minutes: {initialWarningTime.Minutes}");
+            Logger.Debug($"dueTime: {NowUntil(initialWarningTime).Minutes}");
+            Logger.Debug($"period: {period.Minutes}");
 
-            return new Timer(SendCleanupWarning, null, dueTime, period);
+            return new Timer(SendCleanupWarning, null, (int) dueTime.TotalMilliseconds, (int) period.TotalMilliseconds);
         }
 
         private void SendCleanupWarning(object _)
         {
-            Logger.Error($"in SendCleanupWarning");
-
             if (_cleanupWarningMinutesRemaining > 0)
             {
-                Logger.Error($"in SendCleanupWarning, _cleanupWarningMinutesRemaining = {_cleanupWarningMinutesRemaining}");
+                Logger.Debug($"in SendCleanupWarning, _cleanupWarningMinutesRemaining = {_cleanupWarningMinutesRemaining}");
 
                 var minuteText = (_cleanupWarningMinutesRemaining > 1) ? "minutes" : "minute";
 
@@ -1352,7 +1347,7 @@ namespace MBBSEmu.HostProcess
                     _channelDictionary[channel].SendToClient($"|RESET|\r\n|B||MAGENTA|Sorry to interrupt here, but the server will be shutting down in {_cleanupWarningMinutesRemaining} {minuteText} for the nightly \"auto-cleanup\" process. Please finish up and log off... thank you!|RESET|\r\n".EncodeToANSIArray());
                 }
                 _cleanupWarningMinutesRemaining--;
-                Logger.Error($"finished SendCleanupWarning");
+                Logger.Debug($"finished SendCleanupWarning");
             }
             else
             {

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -116,8 +116,8 @@ namespace MBBSEmu.HostProcess
         /// <summary>
         ///     Amount of time to give as a grace period to logoff after nightly cleanup.
         /// </summary>
-        private const int _cleanupGracePeriodMinutes = 10;
-        private readonly TimeSpan _cleanupGracePeriod = TimeSpan.FromMinutes(_cleanupGracePeriodMinutes);
+        private const int CleanupGracePeriodMinutes = 10;
+        private readonly TimeSpan _cleanupGracePeriod = TimeSpan.FromMinutes(CleanupGracePeriodMinutes);
 
 
         /// <summary>
@@ -1321,13 +1321,6 @@ namespace MBBSEmu.HostProcess
             var dueTime = NowUntil(initialWarningTime);
             var period = TimeSpan.FromMinutes(1);
 
-            Logger.Debug($"_cleanupTime Hours: {_cleanupTime.Hours}");
-            Logger.Debug($"_cleanupTime Minutes: {_cleanupTime.Minutes}");
-            Logger.Debug($"initialWarningTime Hours: {initialWarningTime.Hours}");
-            Logger.Debug($"initialWarningTime Minutes: {initialWarningTime.Minutes}");
-            Logger.Debug($"dueTime: {NowUntil(initialWarningTime).Minutes}");
-            Logger.Debug($"period: {period.Minutes}");
-
             return new Timer(SendCleanupWarning, null, (int) dueTime.TotalMilliseconds, (int) period.TotalMilliseconds);
         }
 
@@ -1339,15 +1332,12 @@ namespace MBBSEmu.HostProcess
 
                 var minuteText = (_cleanupWarningMinutesRemaining > 1) ? "minutes" : "minute";
 
-                foreach (var c in _channelDictionary)
+                foreach (var channel in _channelDictionary.Select(c => c.Value.Channel))
                 {
-                    var channel = c.Value.Channel;
-
-                    Logger.Error($"Sending cleanup warning to channel {channel}: {_cleanupWarningMinutesRemaining} {minuteText} until shutdown.");
+                    Logger.Debug($"Sending cleanup warning to channel {channel}: {_cleanupWarningMinutesRemaining} {minuteText} until shutdown.");
                     _channelDictionary[channel].SendToClient($"|RESET|\r\n|B||MAGENTA|Sorry to interrupt here, but the server will be shutting down in {_cleanupWarningMinutesRemaining} {minuteText} for the nightly \"auto-cleanup\" process. Please finish up and log off... thank you!|RESET|\r\n".EncodeToANSIArray());
                 }
                 _cleanupWarningMinutesRemaining--;
-                Logger.Debug($"finished SendCleanupWarning");
             }
             else
             {

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -1338,7 +1338,7 @@ namespace MBBSEmu.HostProcess
                     var channel = c.Value.Channel;
 
                     Logger.Error($"Sending cleanup warning to channel {channel}: {_cleanupWarningMinutesRemaining} {minuteText} until shutdown.");
-                    _channelDictionary[channel].SendToClient($"|RESET|\r\n|B||MAGENTA|Sorry to interrupt here, but the server will be shutting down in {_cleanupWarningMinutesRemaining} {minuteText}. Please finish up and log off.|RESET|\r\n".EncodeToANSIArray());
+                    _channelDictionary[channel].SendToClient($"|RESET|\r\n|B||MAGENTA|Sorry to interrupt here, but the server will be shutting down in {_cleanupWarningMinutesRemaining} {minuteText} for the nightly \"auto-cleanup\" process. Please finish up and log off... thank you!|RESET|\r\n".EncodeToANSIArray());
                 }
                 _cleanupWarningMinutesRemaining--;
                 Logger.Error($"finished SendCleanupWarning");

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -1357,6 +1357,7 @@ namespace MBBSEmu.HostProcess
             else
             {
                 _cleanupWarningTimer.Dispose();
+                _cleanupWarningTimer = null;
             }
         }
 
@@ -1364,6 +1365,7 @@ namespace MBBSEmu.HostProcess
         {
             if (_performCleanup)
             {
+                Logger.Info($"Beginning nightly cleanup process.");
                 _performCleanup = false;
                 DoNightlyCleanup();
 
@@ -1372,6 +1374,7 @@ namespace MBBSEmu.HostProcess
                 _cleanupRestartEvent = null;
 
                 _cleanupWarningTimer = SetupCleanupWarningTimer();
+                Logger.Info($"Nightly cleanup complete.");
             }
         }
 


### PR DESCRIPTION
Note: this code was written largely by ChatGPT 4, so it may look a little different than the surrounding code. It was, of course, still inspected by a human. :)

What appears to be working:
* A warning message is sent 5 minutes before cleanup.

What appears to be missing:
* Even though the code is setup to send more messages every minute, we're only seeing that initial 5 minute warning message. This needs further investigation.

Next steps:
* Ensure a warning message is sent every minute before cleanup.
* (Possibly) adding some tests for this. This file doesn't already have a test suite so not clear to me if the juice is worth the squeeze.
* Compare the color of the cleanup warning text to MBBS proper. Right now we're using the same red color as the final cleanup message, but not sure if this is correct.
* Compare the literal text of the final cleanup message. My spidey sense is that does not match MBBS proper.