### PR TITLE
Use log level configuration

### DIFF
--- a/MBBSEmu/AppSettingsManager.cs
+++ b/MBBSEmu/AppSettingsManager.cs
@@ -1,5 +1,6 @@
 using MBBSEmu.Logging;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -38,6 +39,20 @@ namespace MBBSEmu
             ConfigurationRoot = new ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile(ConfigurationFileName, false, true)
                 .Build();
+
+            //Set Logging Level from Config File if specified
+            if (ConfigurationRoot.GetSection("Console.LogLevel").Exists())
+            {
+                if (Enum.TryParse(typeof(LogLevel), ConfigurationRoot["Console.LogLevel"], out var result))
+                {
+                    logger.SetLevel((LogLevel)result);
+                }
+                else
+                {
+                    _logger.Warn($"Invalid Console.LogLevel specified in {ConfigurationFileName} -- setting default value: Information");
+                    logger.SetLevel(LogLevel.Information);
+                }
+            }
         }
 
         /// <summary>

--- a/MBBSEmu/DependencyInjection/ServiceResolver.cs
+++ b/MBBSEmu/DependencyInjection/ServiceResolver.cs
@@ -7,6 +7,7 @@ using MBBSEmu.HostProcess.Fsd;
 using MBBSEmu.HostProcess.GlobalRoutines;
 using MBBSEmu.HostProcess.HostRoutines;
 using MBBSEmu.IO;
+using MBBSEmu.Logging;
 using MBBSEmu.Memory;
 using MBBSEmu.Resources;
 using MBBSEmu.Server.Socket;
@@ -16,7 +17,6 @@ using MBBSEmu.Util;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
-using MBBSEmu.Logging;
 
 namespace MBBSEmu.DependencyInjection
 {
@@ -47,7 +47,6 @@ namespace MBBSEmu.DependencyInjection
         {
             //Base Configuration Items
             AddSingleton<LogFactory>(overrides);
-            AddSingleton<AppSettingsManager>(overrides);
             AddSingleton<AppSettingsManager>(overrides);
             AddSingleton<PointerDictionary<SessionBase>>(overrides);
             AddSingleton<IResourceManager, ResourceManager>(overrides);

--- a/MBBSEmu/Logging/LogFactory.cs
+++ b/MBBSEmu/Logging/LogFactory.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
@@ -29,6 +30,21 @@ namespace MBBSEmu.Logging
                 throw new KeyNotFoundException($"Logger of type {typeof(T)} not found");
 
             return (T)Loggers[typeof(T)];
+        }
+
+        /// <summary>
+        ///     Sets the Default Log Level for all Loggers
+        /// </summary>
+        /// <param name="level"></param>
+        public void SetLevel(LogLevel level)
+        {
+            foreach (var logger in Loggers)
+            {
+                if (logger.Value is LoggerBase loggerBase)
+                {
+                    loggerBase.SetLogLevel(level);
+                }
+            }
         }
     }
 }

--- a/MBBSEmu/Logging/LoggerBase.cs
+++ b/MBBSEmu/Logging/LoggerBase.cs
@@ -1,4 +1,5 @@
 ﻿using MBBSEmu.Logging.Targets;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 
 namespace MBBSEmu.Logging
@@ -6,6 +7,8 @@ namespace MBBSEmu.Logging
     public abstract class LoggerBase
     {
         protected readonly List<ILoggingTarget> LOGGING_TARGETS = new();
+
+        protected LogLevel ConfiguredLogLevel = LogLevel.Information;
 
         public void RemoveTarget<T>()
         {
@@ -15,6 +18,11 @@ namespace MBBSEmu.Logging
         public void AddTarget(ILoggingTarget target)
         {
             LOGGING_TARGETS.Add(target);
+        }
+
+        public void SetLogLevel(LogLevel logLevel)
+        {
+            ConfiguredLogLevel = logLevel;
         }
     }
 }

--- a/MBBSEmu/Logging/MessageLogger.cs
+++ b/MBBSEmu/Logging/MessageLogger.cs
@@ -26,6 +26,11 @@ namespace MBBSEmu.Logging
         /// <param name="exception">Exception to be Logged</param>
         public void Log(LogLevel logLevel, string message, Exception exception = null)
         {
+            //Ignore Message if it's below the configured log level
+            if((int)logLevel < (int)ConfiguredLogLevel)
+                return;
+
+            //Write to all Logging Targets
             foreach (var target in LOGGING_TARGETS)
             {
                 if(!string.IsNullOrEmpty(message))


### PR DESCRIPTION
Adds support to the new logger to support the config option `Console.LogLevel` (which we should probably just rename to `LogLevel` in a future PR), setting the minimum log level to be used. 