### PR TITLE
Lords of Cyberspace Input Fix

### DIFF
--- a/MBBSEmu/CPU/CpuRegisters.cs
+++ b/MBBSEmu/CPU/CpuRegisters.cs
@@ -104,13 +104,13 @@ namespace MBBSEmu.CPU
             output.Append($"CX={this.CX:X4}  ");
             output.Append($"DX={this.DX:X4}  ");
             output.Append($"DS={this.DS:X4}  ");
-            output.AppendLine($"ES={this.ES:X4}");
+            output.AppendLine($"ES={this.ES:X4} ");
             output.Append($"SI={this.SI:X4}  ");
             output.Append($"DI={this.DI:X4}  ");
             output.Append($"SS={this.SS:X4}  ");
             output.Append($"IP={this.IP:X4}  ");
             output.Append($"SP={this.SP:X4}  ");
-            output.AppendLine($"BP={this.BP:X4}");
+            output.AppendLine($"BP={this.BP:X4} ");
             output.Append("F=");
             output.Append(this.CarryFlag ? "C" : "c");
             output.Append(this.ZeroFlag ? "Z" : "z");

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -926,8 +926,9 @@ namespace MBBSEmu.HostProcess
                             break;
                         }
 
-                        //Always Enqueue Input Ready
-                        session.Status.Enqueue(EnumUserStatus.CR_TERMINATED_STRING_AVAILABLE);
+                        //Always Enqueue Input Ready, if one already not queued (from BTUCHI)
+                        if(session.GetStatus() != EnumUserStatus.CR_TERMINATED_STRING_AVAILABLE)
+                            session.Status.Enqueue(EnumUserStatus.CR_TERMINATED_STRING_AVAILABLE);
 
                         break;
                     }


### PR DESCRIPTION
Fixes #593 input issue with Lords of Cyberspace. 

The main issue is that the majority of modules tested to date use `BTUCHI` to intercept `<ENTER>` or key inputs and invoke input from there. Lords of Cyberspace, while using `BTUCHI`, isn't using it to intercept `<ENTER>`, causing it to be queued up twice.

Documented more thoroughly here:
https://github.com/mbbsemu/MBBSEmu/issues/593#issuecomment-1793288605