### PR TITLE
Debug & Crash Report Fixes

### DIFF
--- a/MBBSEmu.Tests/Extensions/ReadOnlySpanExtensions_Tests.cs
+++ b/MBBSEmu.Tests/Extensions/ReadOnlySpanExtensions_Tests.cs
@@ -1,0 +1,62 @@
+﻿using Xunit;
+using MBBSEmu.Extensions;
+using System;
+
+namespace MBBSEmu.Tests.Extensions
+{
+    /// <summary>
+    ///     Unit Tests for MBBSEmu's Extension Class for ReadOnlySpan
+    /// </summary>
+    public class ReadOnlySpanExtensionsTests
+    {
+        [Fact]
+        public void ToCharSpanTest()
+        {
+            ReadOnlySpan<byte> input = new byte[] { 65, 66, 67 };
+            ReadOnlySpan<char> expected = new char[] { 'A', 'B', 'C' };
+            var result = input.ToCharSpan();
+            Assert.Equal(expected.ToArray(), result.ToArray());
+        }
+
+        [Fact]
+        public void ContainsOnlyTest()
+        {
+            ReadOnlySpan<byte> input = new byte[] { 1, 1, 1 };
+            var result = input.ContainsOnly(1);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ContainsOnlyTest_False()
+        {
+            ReadOnlySpan<byte> input = new byte[] { 1, 2, 1 };
+            var result = input.ContainsOnly(1);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ToHexStringTest()
+        {
+            ReadOnlySpan<byte> input = new byte[] { 1, 2, 3, 4, 5 };
+            var result = input.ToHexString(0, 5);
+            Assert.DoesNotContain("No Data to Display", result);
+            Assert.DoesNotContain("Invalid Address Range", result);
+        }
+
+        [Fact]
+        public void ToHexStringTest_ZeroLength()
+        {
+            ReadOnlySpan<byte> input = new byte[] { 1, 2, 3, 4, 5 };
+            var result = input.ToHexString(0, 0);
+            Assert.Contains("No Data to Display", result);
+        }
+
+        [Fact]
+        public void ToHexStringTest_InvalidLength()
+        {
+            ReadOnlySpan<byte> input = new byte[] { 1, 2, 3, 4, 5 };
+            var result = input.ToHexString(0, 6);
+            Assert.Contains("Invalid Address Range", result);
+        }
+    }
+}

--- a/MBBSEmu.Tests/Extensions/ReadOnlySpanExtensions_Tests.cs
+++ b/MBBSEmu.Tests/Extensions/ReadOnlySpanExtensions_Tests.cs
@@ -39,6 +39,9 @@ namespace MBBSEmu.Tests.Extensions
         {
             ReadOnlySpan<byte> input = new byte[] { 1, 2, 3, 4, 5 };
             var result = input.ToHexString(0, 5);
+
+            Assert.Contains("5 bytes, 0x0000 -> 0x0005", result);
+            Assert.Contains("0000 [ 01 02 03 04 05", result);
             Assert.DoesNotContain("No Data to Display", result);
             Assert.DoesNotContain("Invalid Address Range", result);
         }

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -360,6 +360,7 @@ namespace MBBSEmu.CPU
             {
                 _showDebug = true; //Set to log Register values to console after execution
                 _logger.Debug($"{Registers.CS:X4}:{_currentInstruction.IP16:X4} {_currentInstruction}");
+                _logger.Debug($"{Registers}");
             }
             else
             {

--- a/MBBSEmu/CPU/CpuRegisters.cs
+++ b/MBBSEmu/CPU/CpuRegisters.cs
@@ -97,27 +97,7 @@ namespace MBBSEmu.CPU
         /// <returns></returns>
         public override string ToString()
         {
-            var output = new StringBuilder();
-
-            output.Append($"AX={this.AX:X4}  ");
-            output.Append($"BX={this.BX:X4}  ");
-            output.Append($"CX={this.CX:X4}  ");
-            output.Append($"DX={this.DX:X4}  ");
-            output.Append($"DS={this.DS:X4}  ");
-            output.AppendLine($"ES={this.ES:X4} ");
-            output.Append($"SI={this.SI:X4}  ");
-            output.Append($"DI={this.DI:X4}  ");
-            output.Append($"SS={this.SS:X4}  ");
-            output.Append($"IP={this.IP:X4}  ");
-            output.Append($"SP={this.SP:X4}  ");
-            output.AppendLine($"BP={this.BP:X4} ");
-            output.Append("F=");
-            output.Append(this.CarryFlag ? "C" : "c");
-            output.Append(this.ZeroFlag ? "Z" : "z");
-            output.Append(this.SignFlag ? "S" : "s");
-            output.Append(this.OverflowFlag ? "O" : "o");
-
-            return output.ToString();
+            return Registers.ToString();
         }
     }
 }

--- a/MBBSEmu/CPU/CpuRegisters.cs
+++ b/MBBSEmu/CPU/CpuRegisters.cs
@@ -1,7 +1,6 @@
 using Iced.Intel;
 using MBBSEmu.Memory;
 using System;
-using System.Text;
 
 namespace MBBSEmu.CPU
 {

--- a/MBBSEmu/CPU/RegistersStructs.cs
+++ b/MBBSEmu/CPU/RegistersStructs.cs
@@ -3,6 +3,7 @@ using MBBSEmu.Extensions;
 using MBBSEmu.Memory;
 using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace MBBSEmu.CPU
 {
@@ -505,6 +506,35 @@ namespace MBBSEmu.CPU
             SI = BitConverter.ToUInt16(regs.Slice(8, 2));
             DI = BitConverter.ToUInt16(regs.Slice(10, 2));
             SetF(BitConverter.ToUInt16(regs.Slice(14, 2)));
+        }
+
+        /// <summary>
+        ///     Override of .ToString() to display all register values
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            var output = new StringBuilder();
+
+            output.Append($"AX={this.AX:X4}  ");
+            output.Append($"BX={this.BX:X4}  ");
+            output.Append($"CX={this.CX:X4}  ");
+            output.Append($"DX={this.DX:X4}  ");
+            output.Append($"DS={this.DS:X4}  ");
+            output.AppendLine($"ES={this.ES:X4} ");
+            output.Append($"SI={this.SI:X4}  ");
+            output.Append($"DI={this.DI:X4}  ");
+            output.Append($"SS={this.SS:X4}  ");
+            output.Append($"IP={this.IP:X4}  ");
+            output.Append($"SP={this.SP:X4}  ");
+            output.AppendLine($"BP={this.BP:X4} ");
+            output.Append("F=");
+            output.Append(this.CarryFlag ? "C" : "c");
+            output.Append(this.ZeroFlag ? "Z" : "z");
+            output.Append(this.SignFlag ? "S" : "s");
+            output.Append(this.OverflowFlag ? "O" : "o");
+
+            return output.ToString();
         }
     }
 }

--- a/MBBSEmu/Extensions/ReadOnlySpanExtensions.cs
+++ b/MBBSEmu/Extensions/ReadOnlySpanExtensions.cs
@@ -30,7 +30,7 @@ namespace MBBSEmu.Extensions
         }
 
         /// <summary>
-        ///     Creates a human readable hex string from a ReadOnlySpan of bytes
+        ///     Creates a human-readable hex string from a ReadOnlySpan of bytes
         ///
         ///     The header contains the total number of bytes, the start and end address
         ///     as well as columns for each byte within an 8-bit boundary.
@@ -49,9 +49,19 @@ namespace MBBSEmu.Extensions
                 output.AppendLine(new string('-', 73));
 
                 //Handle Zero Length
-                if (length == 0)
+                if (length <= 0)
                 {
                     output.AppendLine("No Data to Display");
+                    return output.ToString();
+                }
+
+                //Handle Invalid Length
+                if (start + length > readOnlySpan.Length)
+                {
+                    output.AppendLine("Invalid Address Range");
+                    output.AppendLine($"Total Length: {readOnlySpan.Length} bytes");
+                    output.AppendLine($"Start: {start}");
+                    output.AppendLine($"Length: {length}");
                     return output.ToString();
                 }
 

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -6130,7 +6130,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 {
                     tokenList.Add(Module.Memory.GetString(messagePointer).ToArray());
                 }
-                catch (Exception e)
+                catch 
                 {
                     _logger.Warn($"Error Reading string at {messagePointer}, terminating list at {tokenList.Count} elements");
                     break;

--- a/MBBSEmu/Module/CrashReport.cs
+++ b/MBBSEmu/Module/CrashReport.cs
@@ -65,7 +65,7 @@ namespace MBBSEmu.Module
 
             //Registers
             crashReportVariables.Add(_registers.ToString());
-            crashReportVariables.Add(_moduleToReport.Memory.GetMemorySegment(0).Slice(_registers.BP, (_registers.BP - _registers.SP))
+            crashReportVariables.Add(_moduleToReport.Memory.GetMemorySegment(0)
                 .ToHexString(_registers.BP, (ushort)(_registers.BP - _registers.SP)));
 
             var crashTemplate = new ResourceManager().GetString("MBBSEmu.Assets.crashReportTemplate.txt");


### PR DESCRIPTION
- Fixes an Unhandled Exception in Crash Report (inconsistent user of `.ToHexString()` extension)
- Added additional error handling to `.ToHexString()` extension
- Added Unit Tests for `ReadOnlySpan<>()` extension class
- Add Register Values to CPU Debug Output