### PR TITLE
Add -V CLI argument for Version Output

### DIFF
--- a/MBBSEmu/Program.cs
+++ b/MBBSEmu/Program.cs
@@ -270,6 +270,9 @@ namespace MBBSEmu
 
                             break;
                         }
+                        case "-V":
+                            Console.WriteLine($"Version: {new ResourceManager().GetString("MBBSEmu.Assets.version.txt")}");
+                            return;
                         default:
                             Console.WriteLine($"Unknown Command Line Argument: {args[i]}");
                             return;


### PR DESCRIPTION
Adds `-V` as a CLI option to output MBBSEmu Version

This makes getting the version number easier now due to the interactive setup now being added.