### PR TITLE
Fix for SKPWRD

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/ExportedModuleTestBase.cs
+++ b/MBBSEmu.Tests/ExportedModules/ExportedModuleTestBase.cs
@@ -23,9 +23,11 @@ namespace MBBSEmu.Tests.ExportedModules
 {
     public abstract class ExportedModuleTestBase : TestBase, IDisposable
     {
-        // list of ordinals that use the __stdcall convention, which means the callee cleans up the
-        // stack.
-        // __cdecl convention has the caller cleaning up the stack.
+        /// <summary>
+        ///     List of ordinals that use the __stdcall convention, which means the callee cleans up the stack.
+        ///
+        ///     __cdecl convention has the caller cleaning up the stack.
+        /// </summary>
         private static readonly HashSet<ushort> STDCALL_ORDINALS = new HashSet<ushort> {
             654, // f_ldiv
             656, // f_ludiv

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/skpwrd_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/skpwrd_Tests.cs
@@ -33,5 +33,42 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
                 Encoding.ASCII.GetString(
                     mbbsEmuMemoryCore.GetString(mbbsEmuCpuRegisters.GetPointer())));
         }
+
+        /// <summary>
+        ///     These tests are to verify a specific scenario where the final character of the string being parsed
+        ///     is at the last offset in a segment (0xFFFF)
+        /// </summary>
+        /// <param name="inputString"></param>
+        /// <param name="expectedString"></param>
+        [Theory]
+        [InlineData("TEST TEST\0", " TEST\0")]
+        [InlineData("TEST\0", "\0")]
+        [InlineData("\0", "\0")]
+        public void SKPWRD_Test_EndOfSegment(string inputString, string expectedString)
+        {
+            //Reset State
+            Reset();
+
+            //Set Argument Values to be Passed In
+            var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(inputString.Length + 1));
+
+            //Ensure Input String ends in \0
+            if (inputString[^1] != '\0')
+                inputString += '\0';
+
+            //This will change the final character of the string (\0) to be at 0xFFFF
+            stringPointer.Offset = (ushort)(0x10000 - inputString.Length);
+
+            //Get the Segment and we'll allocate this at the end
+            mbbsEmuMemoryCore.SetArray(stringPointer, Encoding.ASCII.GetBytes(inputString));
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, SKPWRD_ORDINAL, new List<FarPtr> { stringPointer });
+
+            //Verify Results
+            Assert.Equal(expectedString,
+                Encoding.ASCII.GetString(
+                    mbbsEmuMemoryCore.GetString(mbbsEmuCpuRegisters.GetPointer())));
+        }
     }
 }

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -7212,7 +7212,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             var stringPointerBase = GetParameterPointer(0);
 
-            for (var i = stringPointerBase.Offset; i < ushort.MaxValue; i++)
+            for (var i = stringPointerBase.Offset; i <= ushort.MaxValue; i++)
             {
                 var currentCharacter = Module.Memory.GetByte(stringPointerBase.Segment, i);
                 if (currentCharacter != 0 && currentCharacter != ' ') continue;


### PR DESCRIPTION
- Fixes a bug with `SKPWRD` where it wouldn't properly skip a word where the final character (`/0`) was at offer `0xFFFF`
- Added Unit Tests to `skpwrd_Tests.cs` to test for this specific scenario

Fixes #613 