### PR TITLE
Apply Default Keys on -DBRESET

### DIFF
--- a/MBBSEmu/Database/Repositories/Account/AccountRepository.cs
+++ b/MBBSEmu/Database/Repositories/Account/AccountRepository.cs
@@ -12,12 +12,9 @@ namespace MBBSEmu.Database.Repositories.Account
     /// <summary>
     ///     Repository Pattern for the MBBSEmu Account Database
     /// </summary>
-    public class AccountRepository : RepositoryBase, IAccountRepository
+    public class AccountRepository(ISessionBuilder sessionBuilder, IResourceManager resourceManager)
+        : RepositoryBase(sessionBuilder, resourceManager), IAccountRepository
     {
-        public AccountRepository(ISessionBuilder sessionBuilder, IResourceManager resourceManager) : base(sessionBuilder, resourceManager)
-        {
-        }
-
         public bool CreateTable()
         {
             var result = Query(EnumQueries.CreateAccountsTable, null);

--- a/MBBSEmu/Database/Repositories/AccountKey/AccountKeyRepository.cs
+++ b/MBBSEmu/Database/Repositories/AccountKey/AccountKeyRepository.cs
@@ -1,18 +1,15 @@
 ﻿using MBBSEmu.Database.Repositories.AccountKey.Model;
 using MBBSEmu.Database.Repositories.AccountKey.Queries;
 using MBBSEmu.Database.Session;
+using MBBSEmu.Resources;
 using System.Collections.Generic;
 using System.Linq;
-using MBBSEmu.Resources;
 
 namespace MBBSEmu.Database.Repositories.AccountKey
 {
-    public class AccountKeyRepository : RepositoryBase, IAccountKeyRepository
+    public class AccountKeyRepository(ISessionBuilder sessionBuilder, IResourceManager resourceManager, AppSettingsManager appSettingsManager) 
+        : RepositoryBase(sessionBuilder, resourceManager), IAccountKeyRepository
     {
-        public AccountKeyRepository(ISessionBuilder sessionBuilder, IResourceManager resourceManager) : base(sessionBuilder, resourceManager)
-        {
-        }
-
         public bool CreateTable()
         {
             var result = Query(EnumQueries.CreateAccountKeysTable, null);
@@ -69,14 +66,21 @@ namespace MBBSEmu.Database.Repositories.AccountKey
             CreateTable();
 
             //Keys for SYSOP
-            InsertAccountKeyByUsername("sysop", "DEMO");
-            InsertAccountKeyByUsername("sysop", "NORMAL");
             InsertAccountKeyByUsername("sysop", "SUPER");
             InsertAccountKeyByUsername("sysop", "SYSOP");
+            ApplyDefaultAccountKeys("sysop");
+
 
             //Keys for GUEST
-            InsertAccountKeyByUsername("guest", "DEMO");
-            InsertAccountKeyByUsername("guest", "NORMAL");
+            ApplyDefaultAccountKeys("guest");
+            return;
+
+            //Local Function to apply default account keys defined in AppSettingsManager
+            void ApplyDefaultAccountKeys(string userName)
+            {
+                foreach (var accountKey in appSettingsManager.DefaultKeys)
+                    InsertAccountKeyByUsername(userName, accountKey);
+            }
         }
     }
 }

--- a/MBBSEmu/Database/Repositories/RepositoryBase.cs
+++ b/MBBSEmu/Database/Repositories/RepositoryBase.cs
@@ -14,11 +14,9 @@ namespace MBBSEmu.Database.Repositories
     ///
     ///     Holds common Dapper Functionality for executing Queries
     /// </summary>
-    public abstract class RepositoryBase : IRepositoryBase, IDisposable
+    public abstract class RepositoryBase(ISessionBuilder sessionBuilder, IResourceManager resourceManager) : IRepositoryBase, IDisposable
     {
-        private readonly IResourceManager _resourceManager;
-
-        private readonly DbConnection _connection;
+        private readonly DbConnection _connection = sessionBuilder.GetConnection();
 
         public void Dispose()
         {
@@ -26,20 +24,14 @@ namespace MBBSEmu.Database.Repositories
             _connection.Dispose();
         }
 
-        protected RepositoryBase(ISessionBuilder sessionBuilder, IResourceManager resourceManager)
-        {
-            _connection = sessionBuilder.GetConnection();
-            _resourceManager = resourceManager;
-        }
-
         public IEnumerable<T> Query<T>(object enumQuery, object parameters)
         {
-            return _connection.Query<T>(_resourceManager.GetString($"{SqlQueryAttribute.Get(enumQuery)}"), parameters);
+            return _connection.Query<T>(resourceManager.GetString($"{SqlQueryAttribute.Get(enumQuery)}"), parameters);
         }
 
         public IEnumerable<dynamic> Query(object enumQuery, object parameters)
         {
-            var sql = _resourceManager.GetString($"{SqlQueryAttribute.Get(enumQuery)}");
+            var sql = resourceManager.GetString($"{SqlQueryAttribute.Get(enumQuery)}");
             return _connection.Query(sql, parameters);
         }
 


### PR DESCRIPTION
The Command Line Argument `-DBRESET` was applying a set of default keys on reset, but not the actual default keys defined in `appsettings.json`. 

This change will apply a fixed set of keys to Sysop (`SUPER`, `SYSOP`) on reset, and then also apply the default keys defined in `appsettings.json`. The `GUEST` account will only have the default keys.