### PR TITLE
Logging & Exception Fixes

### DIFF
--- a/MBBSEmu/CPU/RegistersStructs.cs
+++ b/MBBSEmu/CPU/RegistersStructs.cs
@@ -520,6 +520,7 @@ namespace MBBSEmu.CPU
             output.Append($"BX={this.BX:X4}  ");
             output.Append($"CX={this.CX:X4}  ");
             output.Append($"DX={this.DX:X4}  ");
+            output.Append($"CS={this.CS:X4}  ");
             output.Append($"DS={this.DS:X4}  ");
             output.AppendLine($"ES={this.ES:X4} ");
             output.Append($"SI={this.SI:X4}  ");

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -4059,10 +4059,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             var formattedMessage = FormatPrintf(message, 2);
 
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.BackgroundColor = ConsoleColor.Red;
-            Console.WriteLine($"{Encoding.ASCII.GetString(formattedMessage)}");
-            Console.ResetColor();
+            _logger.Error($"({Module.ModuleIdentifier}) Catastro Failure: {Encoding.ASCII.GetString(formattedMessage)}");
 
             Registers.Halt = true;
         }

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -1362,7 +1362,7 @@ namespace MBBSEmu.HostProcess
             }
 
             //Notify Users and Exit Modules
-            foreach (var c in _channelDictionary.Values.Where(x => x.CurrentModule.ModuleIdentifier == moduleId))
+            foreach (var c in _channelDictionary.Values.Where(x => x.CurrentModule?.ModuleIdentifier == moduleId))
             {
                 if (isCrashed)
                 {


### PR DESCRIPTION
Two small fixes around exception handling. 

1. `CATASTRO` errors were being written to console, not the logger. This means they weren't included in the GUI logs and were lost.
2. When a module errors out and needs to be disabled, users within the module are supposed to be showed a graceful message. This assumes the users are "IN" a module when a crash happens, but when running Login/Logout routines, the user technically isn't "IN" the module to where they are displayed a message.  The result was that MBBSEmu would crash and not disable the module. 

This fix allows the module to still be disabled, and since the users are in non-interactive routines, no need to "Gracefully" exit them, they'll exit anyway.