### PR TITLE
Don't log the user in if we're AT max, not _ABOVE_

### DIFF
--- a/MBBSEmu/Session/Rlogin/RloginSession.cs
+++ b/MBBSEmu/Session/Rlogin/RloginSession.cs
@@ -76,7 +76,7 @@ namespace MBBSEmu.Session.Rlogin
             }
 
             //Check to see if there is an available channel
-            if (_channelDictionary.Count > _configuration.BBSChannels)
+            if (_channelDictionary.Count >= _configuration.BBSChannels)
             {
                 Send($"\r\n|RED||B|{_configuration.BBSTitle} has reached the maximum number of users: {_configuration.BBSChannels} -- Please try again later.\r\n|RESET|".EncodeToANSIArray());
                 SessionState = EnumSessionState.LoggedOff;


### PR DESCRIPTION
- Do not allow a user to connect via Rlogin if we're _AT OR ABOVE_ max defined channels, not just _ABOVE_