### PR TITLE
PHAPI, `TOKOPT`, `CHROPT` and `SAMTO` Fixes

### DIFF
--- a/MBBSEmu.Tests/CPU/IMUL_Tests.cs
+++ b/MBBSEmu.Tests/CPU/IMUL_Tests.cs
@@ -62,6 +62,7 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(-127, -1, 127, false, false)]
         [InlineData(127, -1, -127, false, false)]
         [InlineData(short.MaxValue, -1, short.MinValue + 1, false, false)]
+        [InlineData(short.MaxValue, -2, 2, true, true)]
         public void IMUL_16_R16_3OP_Test(short bxValue, short valueToMultiply, short expectedValue, bool carryFlag,
             bool overflowFlag)
         {
@@ -83,10 +84,12 @@ namespace MBBSEmu.Tests.CPU
 
         [Theory]
         [InlineData(1, -1, -1, false, false)]
+        [InlineData(5, 10, 50, false, false)]
         [InlineData(-1, -1, 1, false, false)]
         [InlineData(-127, -1, 127, false, false)]
         [InlineData(127, -1, -127, false, false)]
         [InlineData(short.MaxValue, -1, short.MinValue + 1, false, false)]
+        [InlineData(short.MaxValue, -2, 2, true, true)]
         public void IMUL_16_M16_3OP_Test(short memoryValue, short valueToMultiply, short expectedValue, bool carryFlag,
             bool overflowFlag)
         {

--- a/MBBSEmu.Tests/CPU/IMUL_Tests.cs
+++ b/MBBSEmu.Tests/CPU/IMUL_Tests.cs
@@ -7,11 +7,14 @@ namespace MBBSEmu.Tests.CPU
     public class IMUL_Tests : CpuTestBase
     {
         [Theory]
-        [InlineData(1, -1, -1, false, false)]
-        [InlineData(-1, -1, 1, false, false)]
-        [InlineData(-127, -1, 127, false, false)]
-        [InlineData(127, -1, -127, false, false)]
-        public void IMUL_8_R8_Test(sbyte alValue, sbyte valueToMultiply, short expectedValue, bool carryFlag,
+        [InlineData(127, 127, 1, 63, true, true)]
+        [InlineData(-1, -1, 1, 0, false, false)]
+        [InlineData(-127, -1, 127, 0, false, false)]
+        [InlineData(-127, 2, 2, -1, true, true)]
+        [InlineData(-127, -127, 1, 63, true, true)]
+        [InlineData(127, -1, -127, -1, false, false)]
+        [InlineData(5, 5, 25, 0, false, false)]
+        public void IMUL_8_R8_Test(sbyte alValue, sbyte valueToMultiply, sbyte expectedALValue, sbyte expectedAHValue, bool carryFlag,
             bool overflowFlag)
         {
             Reset();
@@ -25,17 +28,23 @@ namespace MBBSEmu.Tests.CPU
             mbbsEmuCpuCore.Tick();
 
             //Verify Results
-            Assert.Equal(expectedValue, (sbyte)mbbsEmuCpuRegisters.AL);
+            Assert.Equal(expectedALValue, (sbyte)mbbsEmuCpuRegisters.AL);
+            Assert.Equal(expectedAHValue, (sbyte)mbbsEmuCpuRegisters.AH);
             Assert.Equal(carryFlag, mbbsEmuCpuRegisters.CarryFlag);
             Assert.Equal(overflowFlag, mbbsEmuCpuRegisters.OverflowFlag);
         }
 
         [Theory]
-        [InlineData(1, -1, -1, false, false)]
-        [InlineData(-1, -1, 1, false, false)]
-        [InlineData(-127, -1, 127, false, false)]
-        [InlineData(127, -1, -127, false, false)]
-        [InlineData(short.MaxValue, -1, short.MinValue + 1, false, false)]
+        [InlineData(32767, 1, 32767, false, false)]  // Max positive * 1
+        [InlineData(-32768, 1, -32768, false, false)] // Max negative * 1
+        [InlineData(100, 100, 10000, false, false)] // Positive * Positive
+        [InlineData(-100, -100, 10000, false, false)] // Negative * Negative
+        [InlineData(100, -100, -10000, false, false)] // Positive * Negative
+        [InlineData(32767, 2, -2, true, true)] // Positive overflow case
+        [InlineData(-32768, 2, 0, true, true)] // Negative overflow case
+        [InlineData(0, 32767, 0, false, false)] // Zero * Positive
+        [InlineData(0, -32768, 0, false, false)] // Zero * Negative
+        [InlineData(0, 0, 0, false, false)] // Zero * Zero
         public void IMUL_16_R16_Test(short axValue, short valueToMultiply, short expectedValue, bool carryFlag,
             bool overflowFlag)
         {

--- a/MBBSEmu.Tests/CPU/IMUL_Tests.cs
+++ b/MBBSEmu.Tests/CPU/IMUL_Tests.cs
@@ -1,0 +1,113 @@
+﻿using Iced.Intel;
+using Xunit;
+using static Iced.Intel.AssemblerRegisters;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class IMUL_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(1, -1, -1, false, false)]
+        [InlineData(-1, -1, 1, false, false)]
+        [InlineData(-127, -1, 127, false, false)]
+        [InlineData(127, -1, -127, false, false)]
+        public void IMUL_8_R8_Test(sbyte alValue, sbyte valueToMultiply, short expectedValue, bool carryFlag,
+            bool overflowFlag)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AL = (byte)alValue;
+            mbbsEmuCpuRegisters.BL = (byte)valueToMultiply;
+
+            var instructions = new Assembler(16);
+            instructions.imul(bl);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results
+            Assert.Equal(expectedValue, (sbyte)mbbsEmuCpuRegisters.AL);
+            Assert.Equal(carryFlag, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(overflowFlag, mbbsEmuCpuRegisters.OverflowFlag);
+        }
+
+        [Theory]
+        [InlineData(1, -1, -1, false, false)]
+        [InlineData(-1, -1, 1, false, false)]
+        [InlineData(-127, -1, 127, false, false)]
+        [InlineData(127, -1, -127, false, false)]
+        [InlineData(short.MaxValue, -1, short.MinValue + 1, false, false)]
+        public void IMUL_16_R16_Test(short axValue, short valueToMultiply, short expectedValue, bool carryFlag,
+            bool overflowFlag)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AX = (ushort)axValue;
+            mbbsEmuCpuRegisters.BX = (ushort)valueToMultiply;
+
+            var instructions = new Assembler(16);
+            instructions.imul(bx);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results
+            Assert.Equal(expectedValue, (short)mbbsEmuCpuRegisters.AX);
+            Assert.Equal(carryFlag, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(overflowFlag, mbbsEmuCpuRegisters.OverflowFlag);
+        }
+
+
+        [Theory]
+        [InlineData(1, -1, -1, false, false)]
+        [InlineData(-1, -1, 1, false, false)]
+        [InlineData(-127, -1, 127, false, false)]
+        [InlineData(127, -1, -127, false, false)]
+        [InlineData(short.MaxValue, -1, short.MinValue + 1, false, false)]
+        public void IMUL_16_R16_3OP_Test(short bxValue, short valueToMultiply, short expectedValue, bool carryFlag,
+            bool overflowFlag)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.BX = (ushort)bxValue;
+
+            var instructions = new Assembler(16);
+            //AX = BX * ValueToMultiply
+            instructions.imul(ax, bx, valueToMultiply);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results
+            Assert.Equal(expectedValue, (short)mbbsEmuCpuRegisters.AX);
+            Assert.Equal(carryFlag, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(overflowFlag, mbbsEmuCpuRegisters.OverflowFlag);
+        }
+
+        [Theory]
+        [InlineData(1, -1, -1, false, false)]
+        [InlineData(-1, -1, 1, false, false)]
+        [InlineData(-127, -1, 127, false, false)]
+        [InlineData(127, -1, -127, false, false)]
+        [InlineData(short.MaxValue, -1, short.MinValue + 1, false, false)]
+        public void IMUL_16_M16_3OP_Test(short memoryValue, short valueToMultiply, short expectedValue, bool carryFlag,
+            bool overflowFlag)
+        {
+            Reset();
+
+            //Setup Memory
+            CreateDataSegment(new byte[ushort.MaxValue]);
+            mbbsEmuMemoryCore.SetWord(2,0, (ushort)memoryValue);
+            mbbsEmuCpuRegisters.DS = 2;
+
+            var instructions = new Assembler(16);
+            //AX == DS:[0] * ValueToMultiply
+            instructions.imul(ax, __word_ptr[0], valueToMultiply);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results
+            Assert.Equal(expectedValue, (short)mbbsEmuCpuRegisters.AX);
+            Assert.Equal(carryFlag, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(overflowFlag, mbbsEmuCpuRegisters.OverflowFlag);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/MUL_Tests.cs
+++ b/MBBSEmu.Tests/CPU/MUL_Tests.cs
@@ -1,6 +1,4 @@
 ﻿using Iced.Intel;
-using MBBSEmu.CPU;
-using MBBSEmu.Extensions;
 using Xunit;
 using static Iced.Intel.AssemblerRegisters;
 

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/tokopt_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/tokopt_Tests.cs
@@ -16,7 +16,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData(new[] { "TEST1", "TEST2", "TEST3" }, "TEST2", 2)]
         [InlineData(new[] { "TEST1", "TEST2", "TEST3" }, "Testing Multiple Words: TEST", 0)]
         [InlineData(new[] { "TEST1", "TEST2", "TEST3" }, "Testing Multiple Words: TEST3", 3)]
-        public void stgopt_Test(string[] tokens, string valueToTest, ushort expectedResult)
+        public void tokopt_Test(string[] tokens, string valueToTest, ushort expectedResult)
         {
             //Reset State
             Reset();

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/tokopt_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/tokopt_Tests.cs
@@ -1,0 +1,62 @@
+﻿using MBBSEmu.Memory;
+using MBBSEmu.Module;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class tokopt_Tests : ExportedModuleTestBase
+    {
+        private const int TOKPT_ORDINAL = 602;
+
+        [Theory]
+        [InlineData(new[] { "TEST1", "TEST2", "TEST3" }, "TEST", 0)]
+        [InlineData(new[] { "TEST1", "TEST2", "TEST3" }, "TEST2", 2)]
+        [InlineData(new[] { "TEST1", "TEST2", "TEST3" }, "Testing Multiple Words: TEST", 0)]
+        [InlineData(new[] { "TEST1", "TEST2", "TEST3" }, "Testing Multiple Words: TEST3", 3)]
+        public void stgopt_Test(string[] tokens, string valueToTest, ushort expectedResult)
+        {
+            //Reset State
+            Reset();
+
+            //Allocate Memory for each Token which will be passed in as params to the function
+            var tokenPointers = new List<FarPtr>();
+            foreach(var token in tokens)
+            {
+                var tokenPointer =
+                    mbbsEmuMemoryCore.AllocateVariable($"TOKEN{tokenPointers.Count + 1}", (ushort)(token.Length + 1));
+                mbbsEmuMemoryCore.SetArray(tokenPointer, Encoding.ASCII.GetBytes(token));
+
+                tokenPointers.Add(tokenPointer);
+            }
+
+
+            //Set Argument Values to be Passed In
+            var mcvPointer = (ushort)majorbbs.McvPointerDictionary.Allocate(new McvFile("TEST.MCV",
+                new Dictionary<int, byte[]> { { 0, Encoding.ASCII.GetBytes(valueToTest) } }));
+
+            mbbsEmuMemoryCore.SetPointer("CURRENT-MCV", new FarPtr(0xFFFF, mcvPointer));
+
+            //Build Parameters List
+            var parameters = new List<ushort>();
+            parameters.Add(0); //Ordinal of MCV Value
+            //Add Token Pointers
+            foreach (var tokenPointer in tokenPointers)
+            {
+                parameters.Add(tokenPointer.Offset);
+                parameters.Add(tokenPointer.Segment);
+            }
+            //Terminate with Null Pointer
+            parameters.Add(0);
+            parameters.Add(0);
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, TOKPT_ORDINAL, parameters);
+
+            //Verify Results
+            Assert.Equal(expectedResult, mbbsEmuCpuRegisters.AX);
+        }
+    }
+}

--- a/MBBSEmu.Tests/MBBSEmu.Tests.csproj
+++ b/MBBSEmu.Tests/MBBSEmu.Tests.csproj
@@ -20,13 +20,13 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Iced" Version="1.10.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -955,6 +955,7 @@ namespace MBBSEmu.CPU
         }
 
         /// <summary>
+        ///     OpKind and MemorySize
         /// <summary>
         ///     This is a helper method which takes the resulting value from GetOperandValueUInt64 and signs it depending on the underlying
         ///     OpKind and MemorySize
@@ -2735,22 +2736,7 @@ namespace MBBSEmu.CPU
         [MethodImpl(OpcodeSubroutineCompilerOptimizations)]
         private void Op_Imul_3operand()
         {
-            var operand2 = _currentOperationSize switch
-            {
-                1 => GetOperandValueUInt8(_currentInstruction.Op1Kind, EnumOperandType.Source),
-                2 => GetOperandValueUInt16(_currentInstruction.Op1Kind, EnumOperandType.Source),
-                4 => GetOperandValueUInt32(_currentInstruction.Op1Kind, EnumOperandType.Source),
-                _ => throw new Exception("Unsupported Operation Size")
-            };
-
-            var operand3 = _currentOperationSize switch
-            {
-                1 => GetOperandValueUInt8(_currentInstruction.Op2Kind, EnumOperandType.Source),
-                2 => GetOperandValueUInt16(_currentInstruction.Op2Kind, EnumOperandType.Source),
-                4 => GetOperandValueUInt32(_currentInstruction.Op2Kind, EnumOperandType.Source),
-                _ => throw new Exception("Unsupported Operation Size")
-            uint result;
-            unchecked
+            switch (_currentOperationSize)
             {
                 case 1:
                     Op_Imul_3operand_8();
@@ -2766,8 +2752,12 @@ namespace MBBSEmu.CPU
             }
         }
 
-            WriteToDestination(result);
+        [MethodImpl(OpcodeSubroutineCompilerOptimizations)]
+        private void Op_Imul_3operand_8()
+        {
+            var operand2 = GetOperandValueInt8(_currentInstruction.Op1Kind, EnumOperandType.Source);
             var operand3 = GetOperandValueInt8(_currentInstruction.Op2Kind, EnumOperandType.Source);
+            //Set CarryFlag and OverflowFlag if the result is too large to fit in the destination
         }
 
         [MethodImpl(OpcodeSubroutineCompilerOptimizations)]

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -955,7 +955,89 @@ namespace MBBSEmu.CPU
         }
 
         /// <summary>
+        ///     This is a helper method which takes the resulting value from GetOperandValueUInt8 and signs it depending on the underlying
         ///     OpKind and MemorySize
+        /// </summary>
+        /// <param name="opKind"></param>
+        /// <returns></returns>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private sbyte GetOperandValueInt8(OpKind opKind, EnumOperandType operandType)
+        {
+            var value = GetOperandValueUInt8(opKind, operandType);
+
+            return opKind switch
+            {
+                OpKind.Immediate8 => (sbyte)value,
+                OpKind.Register => (sbyte)value,
+                OpKind.Memory => _currentInstruction.MemorySize switch
+                {
+                    MemorySize.Int8 => (sbyte)value,
+                    _ => throw new Exception($"Invalid Operand Size: {_currentInstruction.MemorySize}")
+                },
+                _ => throw new Exception($"Unsupported OpKind: {opKind}")
+            };
+        }
+
+        /// <summary>
+        ///     This is a helper method which takes the resulting value from GetOperandValueUInt16 and signs it depending on the underlying
+        ///     OpKind and MemorySize
+        /// </summary>
+        /// <param name="opKind"></param>
+        /// <returns></returns>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private short GetOperandValueInt16(OpKind opKind, EnumOperandType operandType)
+        {
+            var value = GetOperandValueUInt16(opKind, operandType);
+
+            return opKind switch
+            {
+                OpKind.Immediate8 => (sbyte)value,
+                OpKind.Immediate16 => (short)value,
+                OpKind.Immediate8to16 => (short)value,
+                OpKind.Register => (short)value,
+                OpKind.Memory => _currentInstruction.MemorySize switch
+                {
+                    MemorySize.Int8 => (sbyte)value,
+                    MemorySize.UInt8 => (byte)value,
+                    MemorySize.Int16 => (short)value,
+                    _ => throw new Exception($"Invalid Operand Size: {_currentInstruction.MemorySize}")
+                },
+                _ => throw new Exception($"Unsupported OpKind: {opKind}")
+            };
+        }
+
+        /// <summary>
+        ///     This is a helper method which takes the resulting value from GetOperandValueUInt64 and signs it depending on the underlying
+        ///     OpKind and MemorySize
+        /// </summary>
+        /// <param name="opKind"></param>
+        /// <returns></returns>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private int GetOperandValueInt32(OpKind opKind, EnumOperandType operandType)
+        {
+            var value = GetOperandValueUInt32(opKind, operandType);
+
+            return opKind switch
+            {
+                OpKind.Immediate8 => (sbyte)value,
+                OpKind.Immediate16 => (short)value,
+                OpKind.Immediate8to16 => (short)value,
+                OpKind.Immediate32 => (int)value,
+                OpKind.Immediate8to32 => (int)value,
+                OpKind.Register => (int)value,
+                OpKind.Memory => _currentInstruction.MemorySize switch
+                {
+                    MemorySize.Int8 => (sbyte)value,
+                    MemorySize.UInt8 => (byte)value,
+                    MemorySize.Int16 => (short)value,
+                    MemorySize.UInt16 => (ushort)value,
+                    MemorySize.Int32 => (int)value,
+                    _ => throw new Exception($"Invalid Operand Size: {_currentInstruction.MemorySize}")
+                },
+                _ => throw new Exception($"Unsupported OpKind: {opKind}")
+            };
+        }
+
         /// <summary>
         ///     This is a helper method which takes the resulting value from GetOperandValueUInt64 and signs it depending on the underlying
         ///     OpKind and MemorySize
@@ -2757,7 +2839,12 @@ namespace MBBSEmu.CPU
         {
             var operand2 = GetOperandValueInt8(_currentInstruction.Op1Kind, EnumOperandType.Source);
             var operand3 = GetOperandValueInt8(_currentInstruction.Op2Kind, EnumOperandType.Source);
+            var result = operand2 * operand3;
+
             //Set CarryFlag and OverflowFlag if the result is too large to fit in the destination
+            Registers.OverflowFlag = Registers.CarryFlag = result is > sbyte.MaxValue or < sbyte.MinValue;
+
+            WriteToDestination((byte)result);
         }
 
         [MethodImpl(OpcodeSubroutineCompilerOptimizations)]

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -2737,9 +2737,9 @@ namespace MBBSEmu.CPU
         {
             var operand2 = _currentOperationSize switch
             {
-                1 => GetOperandValueUInt8(_currentInstruction.Op1Kind, EnumOperandType.Destination),
-                2 => GetOperandValueUInt16(_currentInstruction.Op1Kind, EnumOperandType.Destination),
-                4 => GetOperandValueUInt32(_currentInstruction.Op1Kind, EnumOperandType.Destination),
+                1 => GetOperandValueUInt8(_currentInstruction.Op1Kind, EnumOperandType.Source),
+                2 => GetOperandValueUInt16(_currentInstruction.Op1Kind, EnumOperandType.Source),
+                4 => GetOperandValueUInt32(_currentInstruction.Op1Kind, EnumOperandType.Source),
                 _ => throw new Exception("Unsupported Operation Size")
             };
 

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -5311,7 +5311,16 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var msgnum = GetParameter(0);
 
             //Because the string is null terminated, we get the second to last character
-            var outputValue = McvPointerDictionary[_currentMcvFile.Offset].GetString(msgnum)[^2];
+            var inputValue = McvPointerDictionary[_currentMcvFile.Offset].GetString(msgnum);
+
+            //If it's just a null string
+            if (inputValue.Length <= 1)
+            {
+                Registers.AX = 0;
+                return;
+            }
+
+            var outputValue = inputValue[^2];
 
 #if DEBUG
             _logger.Debug($"({Module.ModuleIdentifier}) Retrieved option {msgnum} from {McvPointerDictionary[_currentMcvFile.Offset].FileName} (MCV Pointer: {_currentMcvFile}): {outputValue}");

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -3177,7 +3177,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var string1Buffer = GetParameterString(0, true);
             var string2Buffer = GetParameterString(2, true);
 
-            Registers.AX = (ushort)(string2Buffer.Contains(string1Buffer, StringComparison.CurrentCultureIgnoreCase) ? 1 : 0);
+            Registers.AX = (ushort)(string2Buffer.StartsWith(string1Buffer, StringComparison.CurrentCultureIgnoreCase) ? 1 : 0);
         }
 
         /// <summary>

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -6114,7 +6114,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             var msgNum = GetParameter(0);
 
-            var tokenList = new List<byte[]>();
+            var tokenList = new List<string>();
 
             for (var i = 1; i < ushort.MaxValue; i += 2)
             {
@@ -6126,7 +6126,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
                 try
                 {
-                    tokenList.Add(Module.Memory.GetString(messagePointer).ToArray());
+                    tokenList.Add(Encoding.ASCII.GetString(Module.Memory.GetString(messagePointer).ToArray()));
                 }
                 catch 
                 {
@@ -6137,9 +6137,12 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             var message = McvPointerDictionary[_currentMcvFile.Offset].GetString(msgNum);
 
+            //Get the last word from the message and cast it back to a byte array
+            var lastWord = Encoding.ASCII.GetString(message).Split(' ').Last();
+
             for (var i = 0; i < tokenList.Count; i++)
             {
-                if (message.SequenceEqual(tokenList[i]))
+                if (lastWord == tokenList[i])
                 {
                     Registers.AX = (ushort)(i + 1);
                     return;

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -5310,7 +5310,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             var msgnum = GetParameter(0);
 
-            var outputValue = McvPointerDictionary[_currentMcvFile.Offset].GetString(msgnum)[0];
+            //Because the string is null terminated, we get the second to last character
+            var outputValue = McvPointerDictionary[_currentMcvFile.Offset].GetString(msgnum)[^2];
 
 #if DEBUG
             _logger.Debug($"({Module.ModuleIdentifier}) Retrieved option {msgnum} from {McvPointerDictionary[_currentMcvFile.Offset].FileName} (MCV Pointer: {_currentMcvFile}): {outputValue}");

--- a/MBBSEmu/HostProcess/ExportedModules/Phapi.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Phapi.cs
@@ -51,8 +51,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
                     DosRealIntr();
                     break;
                 case 16:
-                    //DosAllocRealSeg();
-                    DosCreatedAlias();
+                    DosAllocRealSeg();
+                    //DosCreatedAlias();
                     break;
 
                 default:

--- a/MBBSEmu/MBBSEmu.csproj
+++ b/MBBSEmu/MBBSEmu.csproj
@@ -72,15 +72,15 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Dapper" Version="2.1.21" />
+		<PackageReference Include="Dapper" Version="2.1.35" />
 		<PackageReference Include="Iced" Version="1.10.0" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.7" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-		<PackageReference Include="Terminal.Gui" Version="1.14.1" />
+		<PackageReference Include="Terminal.Gui" Version="1.17.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MBBSEmu/Module/CrashReport.cs
+++ b/MBBSEmu/Module/CrashReport.cs
@@ -65,7 +65,7 @@ namespace MBBSEmu.Module
             {
                 crashReportVariables.Add(_moduleToReport.Memory.GetInstruction(_registers.CS, _registers.IP).ToString());
             }
-            catch (Exception e)
+            catch
             {
                 crashReportVariables.Add("Exception retrieving CPU Instruction");
             }


### PR DESCRIPTION
- Fixed `CHROPT` to use the _last_ character in the MSG file value
- Fixed `TOKOPT` to use the _last_ word in the MSG file value
- Added `TOKOPT` Unit Tests
![image](https://github.com/user-attachments/assets/808aa073-548c-4a5e-b875-1aa4c738524b)
- Fixed `SAMETO` to use the C# equivalent of `.StartsWith()` vs. `.Contains()`
![image](https://github.com/user-attachments/assets/19fb5249-d207-41d0-8c2c-98141209a4e8)
- Updated NuGet Packages to Latest
- Updated `PHAPI` 0x10 to be `DosAllocSeg()` (this will break another module I forget, but is correct for Galactic Empire)
- Fixed 3 Operand `IMUL` Operations