### PR TITLE
Variable Ordinals

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/nctime_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/nctime_Tests.cs
@@ -31,13 +31,14 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Execute Test
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, NCTIME_ORDINAL, new List<ushort> { (ushort) packedTime });
+            var resultPointer = mbbsEmuCpuRegisters.GetPointer();
 
             //Put Garbage After it to ensure the null terminator catches
             var garbagePointer = mbbsEmuMemoryCore.AllocateVariable("GARBAGE", 10);
             mbbsEmuMemoryCore.SetArray(garbagePointer, Encoding.ASCII.GetBytes(new string('C', 10)));
 
             //Verify Results
-            Assert.Equal(expectedTime, Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString("NCTIME")));
+            Assert.Equal(expectedTime, Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString(resultPointer)));
         }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/rawmsg_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/rawmsg_Tests.cs
@@ -1,0 +1,66 @@
+﻿using MBBSEmu.Memory;
+using MBBSEmu.Module;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class rawmsg_Tests : ExportedModuleTestBase
+    {
+        private const int RAWMSG_ORDINAL = 487;
+
+        [Theory]
+        [InlineData(0, "Normal")]
+        [InlineData(1, "")]
+        [InlineData(2, "123456")]
+        [InlineData(3, "--==---")]
+        [InlineData(4, "!@)#!*$")]
+        public void rawmsg_Test(ushort ordinal, string msgValue)
+        {
+            //Reset State
+            Reset();
+
+            //Build a Test Dictionary containing all incorrect values
+            var incorrectValues = new Dictionary<int, byte[]>
+            {
+                { 0, "INCORRECT"u8.ToArray() },
+                { 1, "INCORRECT"u8.ToArray() },
+                { 2, "INCORRECT"u8.ToArray() },
+                { 3, "INCORRECT"u8.ToArray() },
+                { 4, "INCORRECT"u8.ToArray() },
+                { 5, "INCORRECT"u8.ToArray() },
+                { 6, "INCORRECT"u8.ToArray() },
+                { 7, "INCORRECT"u8.ToArray() },
+                { 8, "INCORRECT"u8.ToArray() },
+                { 9, "INCORRECT"u8.ToArray() },
+                { 10, "INCORRECT"u8.ToArray() },
+                { 11, "INCORRECT"u8.ToArray() },
+                { 12, "INCORRECT"u8.ToArray() },
+                { 13, "INCORRECT"u8.ToArray() },
+                { 14, "INCORRECT"u8.ToArray() },
+                { 15, "INCORRECT"u8.ToArray() },
+                { 16, "INCORRECT"u8.ToArray() },
+                { 17, "INCORRECT"u8.ToArray() },
+                { 18, "INCORRECT"u8.ToArray() },
+                { 19, "INCORRECT"u8.ToArray() },
+                { 20, "INCORRECT"u8.ToArray() }
+            };
+
+            //Set Input Ordinal In Dictionary to Correct Value
+            incorrectValues[ordinal] = Encoding.ASCII.GetBytes(msgValue);
+
+            //Set Argument Values to be Passed In
+            var mcvPointer = (ushort)majorbbs.McvPointerDictionary.Allocate(new McvFile("TEST.MCV",
+                incorrectValues));
+
+            mbbsEmuMemoryCore.SetPointer("CURRENT-MCV", new FarPtr(0xFFFF, mcvPointer));
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, RAWMSG_ORDINAL, new List<ushort> { ordinal });
+
+            //Verify Results
+            Assert.Equal(msgValue, Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString(mbbsEmuCpuRegisters.DX, mbbsEmuCpuRegisters.AX, true)));
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/stpans_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/stpans_Tests.cs
@@ -39,6 +39,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Execute Test
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, STPANS_ORDINAL, new List<FarPtr> { stringPointer });
+            var resultPointer = mbbsEmuCpuRegisters.GetPointer();
 
             //Verify Results
             Assert.Equal(expectedString,

--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -146,8 +146,13 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// </summary>
         /// <param name="variableName"></param>
         /// <returns></returns>
-        private protected int GetLocalVariableOrdinal(string variableName) =>
-            LocalVariableOrdinalDictionary[variableName]++;
+        private protected int GetLocalVariableOrdinal(string variableName)
+        {
+            if (!LocalVariableOrdinalDictionary.ContainsKey(variableName))
+                LocalVariableOrdinalDictionary[variableName] = 0;
+
+            return LocalVariableOrdinalDictionary[variableName]++;
+        }
 
         /// <summary>
         ///     Creates a distinct variable name string to use internally when allocating variables

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -308,6 +308,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// <param name="numberOfModules"></param>
         public void SetState(ushort channelNumber)
         {
+            ResetLocalVariableOrdinals();
             ChannelNumber = channelNumber;
 
             _previousMcvFile.Clear();
@@ -1897,7 +1898,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var outputValue = $"{highByte << 16 | lowByte}\0";
 
             //Pre-allocate space for the maximum number of characters for a ulong
-            var variablePointer = Module.Memory.GetOrAllocateVariablePointer("L2AS", 0xFF);
+            var variablePointer = Module.Memory.GetOrAllocateVariablePointer(GetLocalVariableName("L2AS"), 0x20); //32 Byte Buffer
 
             Module.Memory.SetArray(variablePointer, Encoding.Default.GetBytes(outputValue));
 
@@ -2379,7 +2380,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var month = (packedDate >> 5) & 0x000F;
             var day = packedDate & 0x001F;
             var outputDate = $"{month:D2}/{day:D2}/{year % 100}\0";
-            var variablePointer = Module.Memory.GetOrAllocateVariablePointer("NCDATE", (ushort)outputDate.Length);
+            var variablePointer = Module.Memory.GetOrAllocateVariablePointer(GetLocalVariableName("NCDATE"), (ushort)outputDate.Length);
 
             Module.Memory.SetArray(variablePointer.Segment, variablePointer.Offset,
                 Encoding.Default.GetBytes(outputDate));
@@ -2885,7 +2886,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var lineprefix = Encoding.ASCII.GetString(lineprefixBytes);
 
             //Setup Host Memory Variables Pointer
-            var variablePointer = Module.Memory.GetOrAllocateVariablePointer("SCNMDF", 0xFF);
+            var variablePointer = Module.Memory.GetOrAllocateVariablePointer(GetLocalVariableName("SCNMDF"), 0xFF);
 
             var recordFound = false;
             foreach (var line in File.ReadAllLines(Path.Combine(Module.ModulePath, mdfName)))
@@ -2894,7 +2895,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 {
                     var result = Encoding.ASCII.GetBytes(line.Split(':')[1] + "\0");
 
-                    if (result.Length > 256)
+                    if (result.Length > 0xFF)
                         throw new OverflowException("SCNMDF result is > 256 bytes");
 
                     Module.Memory.SetArray(variablePointer.Segment, variablePointer.Offset, result);
@@ -3789,7 +3790,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             var msgnum = GetParameter(0);
 
-            var variablePointer = Module.Memory.GetOrAllocateVariablePointer("GETMSG", 0x1000);
+            var variablePointer = Module.Memory.GetOrAllocateVariablePointer(GetLocalVariableName("GETMSG"), 0x1000);
             var outputValue = McvPointerDictionary[_currentMcvFile.Offset].GetString(msgnum);
 
             if (outputValue.Length > 0x1000)
@@ -4238,7 +4239,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 unpackedMinutes, unpackedSeconds);
 
             var timeString = $"{unpackedTime.ToString("HH:mm:ss")}\0";
-            var variablePointer = Module.Memory.GetOrAllocateVariablePointer("NCTIME", (ushort)timeString.Length);
+            var variablePointer = Module.Memory.GetOrAllocateVariablePointer(GetLocalVariableName("NCTIME"), (ushort)timeString.Length);
 
             Module.Memory.SetArray(variablePointer.Segment, variablePointer.Offset,
                 Encoding.Default.GetBytes(timeString));
@@ -5043,7 +5044,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var stringToStripPointer = GetParameterPointer(0);
             var inputString = Module.Memory.GetString(stringToStripPointer);
 
-            Module.Memory.GetOrAllocateVariablePointer("STPANS", 1920); //Max Screen Size of 80x24
+            Module.Memory.GetOrAllocateVariablePointer(GetLocalVariableName("STPANS"), 1920); //Max Screen Size of 80x24
 
             if (inputString.Length > 1920)
             {
@@ -5286,7 +5287,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             var msgnum = GetParameter(0);
 
-            var variablePointer = Module.Memory.GetOrAllocateVariablePointer("RAWMSG", 0x1000);
+            var variablePointer = Module.Memory.GetOrAllocateVariablePointer(GetLocalVariableName("RAWMSG"), 0x1000);
             var outputValue = McvPointerDictionary[_currentMcvFile.Offset].GetString(msgnum);
 
             if (outputValue.Length > 0x1000)
@@ -6318,7 +6319,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 return;
             }
 
-            var msgScanResultPointer = Module.Memory.GetOrAllocateVariablePointer("MSGSCAN", 0x1000);
+            var msgScanResultPointer = Module.Memory.GetOrAllocateVariablePointer(GetLocalVariableName("MSGSCAN"), 0x1000);
 
             Module.Memory.SetArray(msgScanResultPointer, new byte[0x1000]); //Zero it out
             Module.Memory.SetArray(msgScanResultPointer, msgVariableValue); //Write
@@ -6404,7 +6405,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             var name = GetParameterFilename(0);
 
-            var resultPointer = Module.Memory.GetOrAllocateVariablePointer("GETENV", 0xFF);
+            var resultPointer = Module.Memory.GetOrAllocateVariablePointer(GetLocalVariableName("GETENV"), 0xFF);
 
             switch (name)
             {
@@ -7506,7 +7507,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             var outputValue = $"{(uint)(highByte << 16 | lowByte)}\0";
 
-            var resultPointer = Module.Memory.GetOrAllocateVariablePointer("UL2AS", 0xF);
+            var resultPointer = Module.Memory.GetOrAllocateVariablePointer(GetLocalVariableName("UL2AS"), 0x20); //32 Byte Buffer
 
             Module.Memory.SetArray(resultPointer, Encoding.Default.GetBytes(outputValue));
 

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -5044,7 +5044,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var stringToStripPointer = GetParameterPointer(0);
             var inputString = Module.Memory.GetString(stringToStripPointer);
 
-            Module.Memory.GetOrAllocateVariablePointer(GetLocalVariableName("STPANS"), 1920); //Max Screen Size of 80x24
+            var resultPointer = Module.Memory.GetOrAllocateVariablePointer(GetLocalVariableName("STPANS"), 1920); //Max Screen Size of 80x24
 
             if (inputString.Length > 1920)
             {
@@ -5100,13 +5100,13 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 }
             }
 
-            Module.Memory.SetArray("STPANS", Encoding.ASCII.GetBytes(cleanedStringBuilder.ToString()));
+            Module.Memory.SetArray(resultPointer, Encoding.ASCII.GetBytes(cleanedStringBuilder.ToString()));
 
 #if DEBUG
             _logger.Debug($"({Module.ModuleIdentifier}) Ignoring, not stripping ANSI");
 #endif
 
-            Registers.SetPointer(Module.Memory.GetVariablePointer("STPANS"));
+            Registers.SetPointer(resultPointer);
         }
 
         /// <summary>


### PR DESCRIPTION
- Fix for functions that return strings (or memory pointers) to return unique values for each returned value within a single execution loop
- Ordinals Reset to 0 on each execution loop, allowing for memory to be reused