### PR TITLE
Galactic Empire Fixes (FPU + Input)

### DIFF
--- a/MBBSEmu.Tests/CPU/FLDCW_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FLDCW_Tests.cs
@@ -7,22 +7,41 @@ namespace MBBSEmu.Tests.CPU
 {
     public class FLDCW_Tests : CpuTestBase
     {
-        [Fact]
-        public void FLDCW_Test()
+        /// <summary>
+        ///     Loads the FPU Control Word from Memory and sets the FPU Control Word
+        ///
+        ///     We'll verify this by not only setting the Control Word, but also verify
+        ///     the Round Mode is set correctly
+        ///
+        ///     Rounding Flag Conversion:
+        ///     Rounding Mode = (ControlWord >> 10) &amp; 0x3;
+        ///     0 => MidpointRounding.ToEven
+        ///     1 => MidpointRounding.ToNegativeInfinity
+        ///     2 => MidpointRounding.ToPositiveInfinity
+        ///     3 => MidpointRounding.ToZero
+        /// </summary>
+        [Theory]
+        [InlineData(0x0000, MidpointRounding.ToEven)]
+        [InlineData(0x0400, MidpointRounding.ToNegativeInfinity)]
+        [InlineData(0x0800, MidpointRounding.ToPositiveInfinity)]
+        [InlineData(0x0C00, MidpointRounding.ToZero)]
+        public void FLDCW_Test(ushort controlWord, MidpointRounding roundingMode)
         {
             Reset();
             mbbsEmuCpuRegisters.Fpu.ControlWord = 0;
             CreateDataSegment(new ReadOnlySpan<byte>(), 2);
-            mbbsEmuMemoryCore.SetWord(2,0, 0xFFFF);
+            mbbsEmuMemoryCore.SetArray(2, 0, [0, 0, 0]); //Set some junk data ahead of the actual address
+            mbbsEmuMemoryCore.SetWord(2,3, controlWord);
             mbbsEmuCpuRegisters.DS = 2;
 
             var instructions = new Assembler(16);
-            instructions.fldcw(__word_ptr[0]);
+            instructions.fldcw(__word_ptr[3]);
             CreateCodeSegment(instructions);
 
             mbbsEmuCpuCore.Tick();
 
-            Assert.Equal(0xFFFF, mbbsEmuCpuRegisters.Fpu.ControlWord);
+            Assert.Equal(controlWord, mbbsEmuCpuRegisters.Fpu.ControlWord);
+            Assert.Equal(roundingMode, mbbsEmuCpuRegisters.Fpu.GetRoundingControl());
         }
     }
 }

--- a/MBBSEmu.Tests/CPU/FRNDINT_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FRNDINT_Tests.cs
@@ -10,12 +10,15 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(0.1d, 0d)]
         [InlineData(1.9d, 2d)]
         [InlineData(-1.9d, -2d)]
-        [InlineData(0.5d, 1d)]
+        [InlineData(0.5d, 0d)]
         [InlineData(0.49999999d, 0d)]
         public void FRNDINT_Test(double ST0Value, double expectedValue)
         {
             Reset();
             mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()] = ST0Value;
+
+            //Set FPU Control Word to set rounding to even
+            mbbsEmuCpuRegisters.Fpu.ControlWord = 0x0000000C;
 
             var instructions = new Assembler(16);
             instructions.frndint();

--- a/MBBSEmu.Tests/CPU/FRNDINT_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FRNDINT_Tests.cs
@@ -5,20 +5,40 @@ namespace MBBSEmu.Tests.CPU
 {
     public class FRNDINT_Tests : CpuTestBase
     {
+        /// <summary>
+        ///     Tests the FRNDINT Instruction which rounds the value in ST(0) to the nearest integer
+        ///
+        ///     We'll test this by setting the FPU Control Mode to Round to different modes and verify.
+        /// 
+        ///     Rounding Flag Conversion:
+        ///     Rounding Mode = (ControlWord >> 10) &amp; 0x3;
+        ///     0 => MidpointRounding.ToEven
+        ///     1 => MidpointRounding.ToNegativeInfinity
+        ///     2 => MidpointRounding.ToPositiveInfinity
+        ///     3 => MidpointRounding.ToZero
+        /// </summary>
+        /// <param name="ST0Value"></param>
+        /// <param name="expectedValue"></param>
         [Theory]
-        [InlineData(2.1d, 2d)]
-        [InlineData(0.1d, 0d)]
-        [InlineData(1.9d, 2d)]
-        [InlineData(-1.9d, -2d)]
-        [InlineData(0.5d, 0d)]
-        [InlineData(0.49999999d, 0d)]
-        public void FRNDINT_Test(double ST0Value, double expectedValue)
+        //Round to Even
+        [InlineData(1.5, 2.0, 0x0000)]
+        [InlineData(-1.5, -2.0, 0x0000)]
+        //Round to Negative Infinity
+        [InlineData(1.5, 1.0, 0x0400)]
+        [InlineData(-1.5, -2.0, 0x0400)]
+        //Round to Positive Infinity
+        [InlineData(1.5, 2.0, 0x0800)]
+        [InlineData(-1.5, -1.0, 0x0800)]
+        //Round to Zero
+        [InlineData(1.5, 1.0, 0x0C00)]
+        [InlineData(-1.5, -1.0, 0x0C00)]
+        public void FRNDINT_Test(double ST0Value, double expectedValue, ushort controlWord)
         {
             Reset();
             mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()] = ST0Value;
 
             //Set FPU Control Word to set rounding to even
-            mbbsEmuCpuRegisters.Fpu.ControlWord = 0x0000000C;
+            mbbsEmuCpuRegisters.Fpu.ControlWord = controlWord;
 
             var instructions = new Assembler(16);
             instructions.frndint();

--- a/MBBSEmu/CPU/CpuRegisters.cs
+++ b/MBBSEmu/CPU/CpuRegisters.cs
@@ -89,6 +89,7 @@ namespace MBBSEmu.CPU
         public void PopStackTop() => Registers.Fpu.PopStackTop();
         public void PushStackTop() => Registers.Fpu.PushStackTop();
         public void ClearExceptions() => Registers.Fpu.ClearExceptions();
+        public MidpointRounding GetRoundingControl() => Registers.Fpu.GetRoundingControl();
 
         /// <summary>
         ///     Overridden ToString() to display the current state of the CPU Registers

--- a/MBBSEmu/CPU/EnumOperandType.cs
+++ b/MBBSEmu/CPU/EnumOperandType.cs
@@ -7,6 +7,7 @@
     {
         Destination,
         Source,
-        Count
+        Count,
+        None
     }
 }

--- a/MBBSEmu/CPU/ICpuRegisters.cs
+++ b/MBBSEmu/CPU/ICpuRegisters.cs
@@ -10,20 +10,16 @@ namespace MBBSEmu.CPU
     public interface IFpuRegisters
     {
         ushort StatusWord { get; set; }
-
         ushort ControlWord { get; set; }
-
         void SetFlag(EnumFpuStatusFlags statusFlag);
         void ClearFlag(EnumFpuStatusFlags statusFlag);
-
         byte GetStackTop();
-
         void SetStackTop(byte value);
-
         int GetStackPointer(Register register);
         void PopStackTop();
         void PushStackTop();
         void ClearExceptions();
+        MidpointRounding GetRoundingControl();
     }
 
     /// <summary>

--- a/MBBSEmu/CPU/RegistersStructs.cs
+++ b/MBBSEmu/CPU/RegistersStructs.cs
@@ -22,6 +22,22 @@ namespace MBBSEmu.CPU
 
         public byte GetStackTop() => (byte) ((StatusWord >> 11) & 0x7);
 
+        /// <summary>
+        ///     Gets the FPU Rounding Control by getting the Rounding Control bits from the Control Word and convert it to a C# MidpointRounding enum
+        /// </summary>
+        public MidpointRounding GetRoundingControl()
+        {
+            var roundingControl = (ControlWord >> 10) & 0x3;
+            return roundingControl switch
+            {
+                0 => MidpointRounding.ToEven,
+                1 => MidpointRounding.ToNegativeInfinity,
+                2 => MidpointRounding.ToPositiveInfinity,
+                3 => MidpointRounding.ToZero,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+
         public void SetStackTop(byte value)
         {
             StatusWord &= unchecked((ushort)(~0x3800)); //Zero out the previous value

--- a/MBBSEmu/Extensions/ReadOnlySpanExtensions.cs
+++ b/MBBSEmu/Extensions/ReadOnlySpanExtensions.cs
@@ -30,6 +30,13 @@ namespace MBBSEmu.Extensions
         }
 
         /// <summary>
+        ///     Calls Overloaded method with a default start of 0 and length of the entire ReadOnlySpan
+        /// </summary>
+        /// <param name="readOnlySpan"></param>
+        /// <returns></returns>
+        public static string ToHexString(this ReadOnlySpan<byte> readOnlySpan) =>  readOnlySpan.ToHexString(0, (ushort)readOnlySpan.Length);
+
+        /// <summary>
         ///     Creates a human-readable hex string from a ReadOnlySpan of bytes
         ///
         ///     The header contains the total number of bytes, the start and end address

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -4338,7 +4338,6 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             Module.Memory.SetArray("INPUT", Encoding.ASCII.GetBytes(parsedInput));
             Module.Memory.SetWord("MARGC", margCount);
-            //setINPLEN();
         }
 
         /// <summary>
@@ -8372,12 +8371,6 @@ namespace MBBSEmu.HostProcess.ExportedModules
             //Sets DX:AX registers to the return value
             Registers.SetPointer(returnPointer);
         }
-
-        /// <summary>
-        /// Sets the INPLEN variable based on the length of INPUT
-        /// </summary>
-        /// <returns>The value written to INPLEN</returns>
-        private ushort setINPLEN() => setINPLEN(Module.Memory.GetVariablePointer("INPUT"));
 
         /// <summary>
         /// Sets the INPLEN variable based on the length of the string from input

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -4304,7 +4304,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var margvPointer = new FarPtr(Module.Memory.GetVariablePointer("MARGV"));
             var margnPointer = new FarPtr(Module.Memory.GetVariablePointer("MARGN"));
 
-            var margCount = (ushort)inputComponents.Count(x => !string.IsNullOrEmpty(x));
+            var margCount = (ushort)inputComponents.Count(x => !string.IsNullOrEmpty(x) && x != "\0");
 
             Module.Memory.SetPointer(margvPointer, inputPointer); //Set 1st command to start at start of input
             margvPointer.Offset += FarPtr.Size;

--- a/MBBSEmu/Module/MsgFile.cs
+++ b/MBBSEmu/Module/MsgFile.cs
@@ -78,6 +78,11 @@ namespace MBBSEmu.Module
         private static bool IsAlnum(char c) =>
             char.IsLetterOrDigit(c);
 
+        /// <summary>
+        ///     Ensures that all line endings are CRLF
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
         private static MemoryStream FixLineEndings(MemoryStream input)
         {
             var rawMessage = input.ToArray();


### PR DESCRIPTION
- Refactor CPU Debugging
    - Moved code to "init" on CPU load, not every Tick
    - Added Variable Watching
- Fix FPU Rounding
    - Fixed FPU Control Word Loading (`FLDCW`)
    - Utilizes FPU Control Word for Midpoint Rounding Mode
    - Implement FPU Control Word mode for Rounding in FPU OpCodes (`FISTP`, `FRNDINT`)
- Add Extension Method `ToHexString()` on `ReadOnlyArray` to print the entire Array
- Removed Unused Code
- Added Method Comment on currently Uncommented Code
- Fix handling of trailing spaces on input in `parsein` (Trailing NULLs)