### PR TITLE
Removes an extra 00 byte at the end of packets.

### DIFF
--- a/MBBSEmu/Session/Rlogin/RloginSession.cs
+++ b/MBBSEmu/Session/Rlogin/RloginSession.cs
@@ -133,7 +133,14 @@ namespace MBBSEmu.Session.Rlogin
                  if (_configuration.RloginCompatibility == EnumRloginCompatibility.WG3NT && bytesReceived == 12 && clientData[5] == 24)
                      return (null, 0);
 
-                 return (clientData, bytesReceived);
+                // Fix an issue with RLogin clients that sends a 0 byte at the end of the packet
+                _logger.Debug("RLogin -- ClientData Received: " + BitConverter.ToString(clientData, 0, bytesReceived));
+                if (clientData[bytesReceived - 1] == 0)
+                {
+                    bytesReceived--;
+                }
+
+                return (clientData, bytesReceived);
              }
 
              for (var i = 0; i < bytesReceived; ++i)

--- a/MBBSEmu/Session/Rlogin/RloginSession.cs
+++ b/MBBSEmu/Session/Rlogin/RloginSession.cs
@@ -134,7 +134,7 @@ namespace MBBSEmu.Session.Rlogin
                      return (null, 0);
 
                 // Fix an issue with RLogin clients that sends a 0 byte at the end of the packet
-                if (clientData[bytesReceived - 1] == 0)
+                if (bytesReceived > 1 && clientData[bytesReceived - 1] == 0)
                 {
                     bytesReceived--;
                 }

--- a/MBBSEmu/Session/Rlogin/RloginSession.cs
+++ b/MBBSEmu/Session/Rlogin/RloginSession.cs
@@ -134,7 +134,6 @@ namespace MBBSEmu.Session.Rlogin
                      return (null, 0);
 
                 // Fix an issue with RLogin clients that sends a 0 byte at the end of the packet
-                _logger.Debug("RLogin -- ClientData Received: " + BitConverter.ToString(clientData, 0, bytesReceived));
                 if (clientData[bytesReceived - 1] == 0)
                 {
                     bytesReceived--;


### PR DESCRIPTION
This fix removes extra '0x00' bytes at the end of client data on RLogin connections.
This fixes an issue with T-LORD on Linux64 systems, when accessing it with TelnetDoor.
Every time an <ENTER> key was hit, the bytes '0x0D 0x00' were received, and T-LORD understands it as 2 <ENTER>s instead of one. On situations in which the bug doesn't happen, the received bytes array contains only one byte: '0x0D'. This fix decrements the bytesReceived amount by 1, when the last character on the array is 0. I didn't need to modify the byte array itself.
It was tested on T-LORD and the bug was fixed. I also tested it on MajorMUD, and it continues to work fine after the fix.
The Debug line was needed to detect the issue, but can be removed if necessary.