### PR TITLE
Fix incorrect x86 opcode implementations in CpuCore

### DIFF
--- a/MBBSEmu.Tests/CPU/ADC_Tests.cs
+++ b/MBBSEmu.Tests/CPU/ADC_Tests.cs
@@ -62,5 +62,49 @@ namespace MBBSEmu.Tests.CPU
             Assert.False(mbbsEmuCpuRegisters.OverflowFlag);
             Assert.False(mbbsEmuCpuRegisters.SignFlag);
         }
+
+        [Fact]
+        public void ADC_AL_IMM8_SourceMaxValueWithCarryIn_DoesNotWrapCarryFlag()
+        {
+            Reset();
+            CreateCodeSegment(new byte[]
+            {
+                //ADC AL, 0xFF
+                0x14, 0xFF
+            });
+            mbbsEmuCpuRegisters.AL = 0x00;
+            mbbsEmuCpuRegisters.F = mbbsEmuCpuRegisters.F.SetFlag((ushort)EnumFlags.CF);
+
+            //Process Instruction
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results: 0x00 + 0xFF + 1 == 0x100, so AL wraps to 0x00 but Carry must be set
+            Assert.Equal(0x00, mbbsEmuCpuRegisters.AL);
+            Assert.True(mbbsEmuCpuRegisters.CarryFlag);
+            Assert.True(mbbsEmuCpuRegisters.ZeroFlag);
+            Assert.False(mbbsEmuCpuRegisters.OverflowFlag);
+        }
+
+        [Fact]
+        public void ADC_AX_IMM16_SourceMaxValueWithCarryIn_DoesNotWrapCarryFlag()
+        {
+            Reset();
+            CreateCodeSegment(new byte[]
+            {
+                //ADC AX, 0xFFFF
+                0x15, 0xFF, 0xFF
+            });
+            mbbsEmuCpuRegisters.AX = 0x0000;
+            mbbsEmuCpuRegisters.F = mbbsEmuCpuRegisters.F.SetFlag((ushort)EnumFlags.CF);
+
+            //Process Instruction
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results: 0x0000 + 0xFFFF + 1 == 0x10000, so AX wraps to 0x0000 but Carry must be set
+            Assert.Equal(0x0000, mbbsEmuCpuRegisters.AX);
+            Assert.True(mbbsEmuCpuRegisters.CarryFlag);
+            Assert.True(mbbsEmuCpuRegisters.ZeroFlag);
+            Assert.False(mbbsEmuCpuRegisters.OverflowFlag);
+        }
     }
 }

--- a/MBBSEmu.Tests/CPU/ADD_Tests.cs
+++ b/MBBSEmu.Tests/CPU/ADD_Tests.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using Iced.Intel;
+using System;
 using Xunit;
+using static Iced.Intel.AssemblerRegisters;
 
 namespace MBBSEmu.Tests.CPU
 {
@@ -613,6 +615,48 @@ namespace MBBSEmu.Tests.CPU
             Assert.False(mbbsEmuCpuRegisters.ZeroFlag);
             Assert.False(mbbsEmuCpuRegisters.OverflowFlag);
             Assert.False(mbbsEmuCpuRegisters.SignFlag);
+        }
+
+        [Theory]
+        [InlineData(0x0F, 0x01, true)] // Low nibble carries out of bit 3 (0xF + 0x1 == 0x10)
+        [InlineData(0x08, 0x08, true)] // Low nibble carries out of bit 3 (0x8 + 0x8 == 0x10)
+        [InlineData(0x01, 0x01, false)] // No carry out of the low nibble
+        [InlineData(0x0F, 0x00, false)] // No carry, addend contributes nothing to the low nibble
+        public void ADD_AL_IMM8_AuxiliaryCarryFlag(byte alValue, byte value, bool expectedAuxiliaryCarryFlag)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AL = alValue;
+            CreateCodeSegment(new byte[] { 0x04, value });
+
+            //Process Instruction
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Flags
+            Assert.Equal(expectedAuxiliaryCarryFlag, mbbsEmuCpuRegisters.AuxiliaryCarryFlag);
+        }
+
+        [Theory]
+        [InlineData(0x00010000u, 0x00010000u, 0x00020000u, false, false)] // Result needs more than 16 bits, must not be truncated
+        [InlineData(0xFFFFFFFFu, 0x00000001u, 0x00000000u, true, false)] // Full 32-bit wraparound sets Carry
+        [InlineData(0x7FFFFFFFu, 0x00000001u, 0x80000000u, false, true)] // Full 32-bit signed overflow sets Overflow
+        public void ADD_EAX_EBX_32Bit(uint eaxValue, uint ebxValue, uint expectedValue, bool expectedCarryFlag,
+            bool expectedOverflowFlag)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.EAX = eaxValue;
+            mbbsEmuCpuRegisters.EBX = ebxValue;
+
+            var instructions = new Assembler(16);
+            instructions.add(eax, ebx);
+            CreateCodeSegment(instructions);
+
+            //Process Instruction
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results
+            Assert.Equal(expectedValue, mbbsEmuCpuRegisters.EAX);
+            Assert.Equal(expectedCarryFlag, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(expectedOverflowFlag, mbbsEmuCpuRegisters.OverflowFlag);
         }
     }
 }

--- a/MBBSEmu.Tests/CPU/IMUL_Tests.cs
+++ b/MBBSEmu.Tests/CPU/IMUL_Tests.cs
@@ -121,5 +121,32 @@ namespace MBBSEmu.Tests.CPU
             Assert.Equal(carryFlag, mbbsEmuCpuRegisters.CarryFlag);
             Assert.Equal(overflowFlag, mbbsEmuCpuRegisters.OverflowFlag);
         }
+
+        [Theory]
+        [InlineData(1, -1, -1, false, false)] // Simple negative result, must not treat EAX as unsigned
+        [InlineData(-1, -1, 1, false, false)] // Negative * Negative == Positive
+        [InlineData(-127, -1, 127, false, false)]
+        [InlineData(int.MaxValue, -1, int.MinValue + 1, false, false)]
+        [InlineData(int.MaxValue, 2, -2, true, true)] // Overflows 32 bits, CF/OF must be set
+        [InlineData(int.MinValue, -1, int.MinValue, true, true)] // Overflows 32 bits
+        [InlineData(0, -1, 0, false, false)]
+        public void IMUL_32_R32_Test(int eaxValue, int valueToMultiply, int expectedValue, bool carryFlag,
+            bool overflowFlag)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.EAX = unchecked((uint)eaxValue);
+            mbbsEmuCpuRegisters.EBX = unchecked((uint)valueToMultiply);
+
+            var instructions = new Assembler(16);
+            instructions.imul(ebx);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results
+            Assert.Equal(expectedValue, (int)mbbsEmuCpuRegisters.EAX);
+            Assert.Equal(carryFlag, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(overflowFlag, mbbsEmuCpuRegisters.OverflowFlag);
+        }
     }
 }

--- a/MBBSEmu.Tests/CPU/NOT_Tests.cs
+++ b/MBBSEmu.Tests/CPU/NOT_Tests.cs
@@ -1,0 +1,64 @@
+using Iced.Intel;
+using Xunit;
+using static Iced.Intel.AssemblerRegisters;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class NOT_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData((byte)0x00, (byte)0xFF)]
+        [InlineData((byte)0xFF, (byte)0x00)]
+        [InlineData((byte)0x0F, (byte)0xF0)]
+        public void NOT_AL(byte alValue, byte expectedValue)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AL = alValue;
+
+            var instructions = new Assembler(16);
+            instructions.not(al);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(expectedValue, mbbsEmuCpuRegisters.AL);
+        }
+
+        [Theory]
+        [InlineData((ushort)0x0000, (ushort)0xFFFF)]
+        [InlineData((ushort)0xFFFF, (ushort)0x0000)]
+        [InlineData((ushort)0x00FF, (ushort)0xFF00)]
+        public void NOT_AX(ushort axValue, ushort expectedValue)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AX = axValue;
+
+            var instructions = new Assembler(16);
+            instructions.not(ax);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(expectedValue, mbbsEmuCpuRegisters.AX);
+        }
+
+        [Theory]
+        [InlineData(0x00000000u, 0xFFFFFFFFu)] // Must invert all 32 bits, not just the low 16
+        [InlineData(0xFFFFFFFFu, 0x00000000u)]
+        [InlineData(0x0000FFFFu, 0xFFFF0000u)]
+        [InlineData(0xFF00FF00u, 0x00FF00FFu)]
+        public void NOT_EAX_32Bit(uint eaxValue, uint expectedValue)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.EAX = eaxValue;
+
+            var instructions = new Assembler(16);
+            instructions.not(eax);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(expectedValue, mbbsEmuCpuRegisters.EAX);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/RCL_Tests.cs
+++ b/MBBSEmu.Tests/CPU/RCL_Tests.cs
@@ -12,6 +12,10 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(0x0001, 1, false, 0x0002, false, false)] // Simple rotate left
         [InlineData(0x0000, 1, true, 0x0001, false, false)] // Rotate with carry flag set, no bit set in value
         [InlineData(0xFFFF, 4, false, 0xFFF7, true, false)] // Rotate left multiple times
+        [InlineData(0x4000, 1, false, 0x8000, false, true)] // Sign bit (bit 15) set by rotation must set OF, not bit 7
+        [InlineData(0x0040, 1, false, 0x0080, false, false)] // Bit 7 set by rotation must NOT set OF when bit 15 is unaffected
+        [InlineData(0x0001, 33, false, 0x0002, false, false)] // Count must mask to 0x1F (33 & 0x1F == 1), same as a single rotate
+        [InlineData(0x0001, 18, false, 0x0002, false, false)] // Count 18 masks to 18 (0x1F), then reduces mod 17 == 1
         public void Op_Rcl_16_Test(ushort axValue, byte bitsToRotate, bool initialCarryFlag, ushort expectedResult,
             bool expectedCarryFlag, bool expectedOverflowFlag)
         {
@@ -36,6 +40,7 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(0x01, 1, false, 0x02, false, false)] // Simple rotate left
         [InlineData(0x00, 1, true, 0x01, false, false)] // Rotate with carry flag set, no bit set in value
         [InlineData(0xFF, 4, false, 0xF7, true, false)] // Rotate left multiple times
+        [InlineData(0x01, 10, false, 0x02, false, false)] // Count must mask to 0x1F (10 stays 10), then reduce mod 9 == 1
         public void Op_Rcl_8_Test(byte alValue, byte bitsToRotate, bool initialCarryFlag, ushort expectedResult,
             bool expectedCarryFlag, bool expectedOverflowFlag)
         {

--- a/MBBSEmu.Tests/CPU/RCR_Tests.cs
+++ b/MBBSEmu.Tests/CPU/RCR_Tests.cs
@@ -17,6 +17,7 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(0x3E, 2, 0xF, true, false)]
         [InlineData(0xFFFF, 1, 0x7FFF, true, true)]
         [InlineData(0xFFFF, 2, 0xBFFF, true, false)]
+        [InlineData(0xFFFF, 18, 0x7FFF, true, true)] // Count must mask to 0x1F (18 stays 18), then reduce mod 17 == 1
         public void RCR_AX_IMM16_CF_CLEAR(ushort axValue, byte bitsToRotate, ushort expectedValue,
             bool expectedCFValue, bool expectedOFValue)
         {
@@ -67,6 +68,7 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(0xFF, 2, 0xBF, true, false)]
         [InlineData(0x0, 1, 0x0, false, false)]
         [InlineData(0xE, 1, 0x7, false, false)]
+        [InlineData(0xF, 10, 0x7, true, false)] // Count must mask to 0x1F (10 stays 10), then reduce mod 9 == 1
         public void RCR_AH_IMM8_CF_CLEAR(byte ahValue, byte bitsToRotate, byte expectedValue, bool expectedCFValue, bool expectedOFValue)
         {
             Reset();

--- a/MBBSEmu.Tests/CPU/Registers_Tests.cs
+++ b/MBBSEmu.Tests/CPU/Registers_Tests.cs
@@ -131,5 +131,21 @@ namespace MBBSEmu.Tests.CPU
 
             regs.ESI.Should().Be(0);
         }
+
+        [Fact]
+        public void Fpu_GetStackPointer_WrapsAroundCircularStack()
+        {
+            var fpu = FpuRegistersStruct.Create();
+
+            //After a single push, StackTop points at physical slot 0 (ST0)
+            fpu.PushStackTop();
+            fpu.GetStackTop().Should().Be(0);
+
+            //ST7 relative to a StackTop of 0 must wrap around to physical slot 1,
+            //not go negative and throw when used to index the FpuStack array
+            fpu.GetStackPointer(Iced.Intel.Register.ST0).Should().Be(0);
+            fpu.GetStackPointer(Iced.Intel.Register.ST1).Should().Be(7);
+            fpu.GetStackPointer(Iced.Intel.Register.ST7).Should().Be(1);
+        }
     }
 }

--- a/MBBSEmu.Tests/CPU/SBB_Tests.cs
+++ b/MBBSEmu.Tests/CPU/SBB_Tests.cs
@@ -1,0 +1,69 @@
+using MBBSEmu.CPU;
+using MBBSEmu.Extensions;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class SBB_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(0x05, 0x03, false, 0x02, false)] // Simple subtraction, no borrow-in
+        [InlineData(0x05, 0x03, true, 0x01, false)] // Subtraction with borrow-in, no resulting borrow
+        [InlineData(0x00, 0x00, true, 0xFF, true)] // Borrow-in on zero operands must borrow
+        public void SBB_AL_IMM8(byte alValue, byte value, bool initialCarryFlag, byte expectedValue,
+            bool expectedCarryFlag)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AL = alValue;
+            mbbsEmuCpuRegisters.CarryFlag = initialCarryFlag;
+
+            //SBB AL, imm8
+            CreateCodeSegment(new byte[] { 0x1C, value });
+
+            //Process Instruction
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results
+            Assert.Equal(expectedValue, mbbsEmuCpuRegisters.AL);
+            Assert.Equal(expectedCarryFlag, mbbsEmuCpuRegisters.CarryFlag);
+        }
+
+        [Fact]
+        public void SBB_AL_IMM8_SourceMaxValueWithBorrowIn_DoesNotWrapCarryFlag()
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AL = 0x00;
+            mbbsEmuCpuRegisters.CarryFlag = true;
+
+            //SBB AL, 0xFF
+            CreateCodeSegment(new byte[] { 0x1C, 0xFF });
+
+            //Process Instruction
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results: 0x00 - 0xFF - 1 == -256, which is congruent to 0x00 (mod 256), and a borrow occurred
+            Assert.Equal(0x00, mbbsEmuCpuRegisters.AL);
+            Assert.True(mbbsEmuCpuRegisters.CarryFlag);
+            Assert.True(mbbsEmuCpuRegisters.ZeroFlag);
+        }
+
+        [Fact]
+        public void SBB_AX_IMM16_SourceMaxValueWithBorrowIn_DoesNotWrapCarryFlag()
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AX = 0x0000;
+            mbbsEmuCpuRegisters.CarryFlag = true;
+
+            //SBB AX, 0xFFFF
+            CreateCodeSegment(new byte[] { 0x1D, 0xFF, 0xFF });
+
+            //Process Instruction
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results: 0x0000 - 0xFFFF - 1 == -65536, which is congruent to 0x0000 (mod 65536), and a borrow occurred
+            Assert.Equal(0x0000, mbbsEmuCpuRegisters.AX);
+            Assert.True(mbbsEmuCpuRegisters.CarryFlag);
+            Assert.True(mbbsEmuCpuRegisters.ZeroFlag);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/SHLD_Tests.cs
+++ b/MBBSEmu.Tests/CPU/SHLD_Tests.cs
@@ -13,6 +13,7 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(0xFFFF0000, 0xFFFF0000, 16, 0x0000FFFF, true, false, false, false)]
         [InlineData(0x7FFFFFFF, 0xFFFFFFFF, 1, 0xFFFFFFFF, false, true, true, false)]
         [InlineData(0x80000000, 0x00000000, 1, 0x00000000, true, true, false, true)]
+        [InlineData(0x40000000, 0x00000000, 1, 0x80000000, false, true, true, false)] // Sign change with a source operand that is not itself negative
         public void SHLD_EAX_EBX_IMM8(uint eaxValue, uint ebxValue, byte count, uint expectedValue, bool carryFlag, bool overflowFlag, bool signFlag, bool zeroFlag)
         {
             Reset();
@@ -40,6 +41,7 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(0xFFFF0000, 0xFFFF0000, 16, 0x0000FFFF, true, false, false, false)]
         [InlineData(0x7FFFFFFF, 0xFFFFFFFF, 1, 0xFFFFFFFF, false, true, true, false)]
         [InlineData(0x80000000, 0x00000000, 1, 0x00000000, true, true, false, true)]
+        [InlineData(0x40000000, 0x00000000, 1, 0x80000000, false, true, true, false)] // Sign change with a source operand that is not itself negative
         public void SHLD_EAX_EBX_CL(uint eaxValue, uint ebxValue, byte count, uint expectedValue, bool carryFlag, bool overflowFlag, bool signFlag, bool zeroFlag)
         {
             Reset();

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -1610,11 +1610,11 @@ namespace MBBSEmu.CPU
             var destination = GetOperandValueUInt8(_currentInstruction.Op0Kind, EnumOperandType.Destination);
             unchecked
             {
-                if (Registers.CarryFlag)
-                    source += 1;
+                var borrowIn = Registers.CarryFlag ? 1 : 0;
+                var wideResult = destination - source - borrowIn;
+                var result = (byte)wideResult;
 
-                var result = (byte)(destination - source);
-                Flags_EvaluateCarry(EnumArithmeticOperation.Subtraction, result, destination);
+                Registers.CarryFlag = wideResult < 0;
                 Flags_EvaluateOverflow(EnumArithmeticOperation.Subtraction, result, destination, source);
                 Flags_EvaluateSignZero(result);
                 return result;
@@ -1629,11 +1629,11 @@ namespace MBBSEmu.CPU
 
             unchecked
             {
-                if (Registers.CarryFlag)
-                    source += 1;
+                var borrowIn = Registers.CarryFlag ? 1 : 0;
+                var wideResult = destination - source - borrowIn;
+                var result = (ushort)wideResult;
 
-                var result = (ushort)(destination - source);
-                Flags_EvaluateCarry(EnumArithmeticOperation.Subtraction, result, destination);
+                Registers.CarryFlag = wideResult < 0;
                 Flags_EvaluateOverflow(EnumArithmeticOperation.Subtraction, result, destination, source);
                 Flags_EvaluateSignZero(result);
                 return result;
@@ -1734,6 +1734,12 @@ namespace MBBSEmu.CPU
         {
             var destination = GetOperandValueUInt8(_currentInstruction.Op0Kind, EnumOperandType.Destination);
             var source = GetOperandValueUInt8(_currentInstruction.Op1Kind, EnumOperandType.Source);
+
+            //x86 masks the rotate count to 5 bits, then reduces it modulo (width+1) since
+            //the Carry Flag participates in the rotation as an extra, 9th bit
+            source &= 0x1F;
+            source %= 9;
+
             unchecked
             {
                 var result = destination;
@@ -1779,6 +1785,12 @@ namespace MBBSEmu.CPU
         {
             var destination = GetOperandValueUInt16(_currentInstruction.Op0Kind, EnumOperandType.Destination);
             var source = GetOperandValueUInt16(_currentInstruction.Op1Kind, EnumOperandType.Source);
+
+            //x86 masks the rotate count to 5 bits, then reduces it modulo (width+1) since
+            //the Carry Flag participates in the rotation as an extra, 17th bit
+            source &= 0x1F;
+            source %= 17;
+
             unchecked
             {
                 var result = destination;
@@ -1829,6 +1841,11 @@ namespace MBBSEmu.CPU
             var destination = GetOperandValueUInt8(_currentInstruction.Op0Kind, EnumOperandType.Destination);
             var source = GetOperandValueUInt8(_currentInstruction.Op1Kind, EnumOperandType.Source);
 
+            //x86 masks the rotate count to 5 bits, then reduces it modulo (width+1) since
+            //the Carry Flag participates in the rotation as an extra, 9th bit
+            source &= 0x1F;
+            source %= 9;
+
             unchecked
             {
                 var result = destination;
@@ -1862,6 +1879,11 @@ namespace MBBSEmu.CPU
             var destination = GetOperandValueUInt16(_currentInstruction.Op0Kind, EnumOperandType.Destination);
             var source = GetOperandValueUInt16(_currentInstruction.Op1Kind, EnumOperandType.Source);
 
+            //x86 masks the rotate count to 5 bits, then reduces it modulo (width+1) since
+            //the Carry Flag participates in the rotation as an extra, 17th bit
+            source &= 0x1F;
+            source %= 17;
+
             unchecked
             {
                 var result = destination;
@@ -1883,7 +1905,7 @@ namespace MBBSEmu.CPU
 
                 //For 1 Bit Rotations, we evaluate Overflow
                 if (source == 1)
-                    Registers.OverflowFlag = result.IsBitSet(7) ^ Registers.CarryFlag;
+                    Registers.OverflowFlag = result.IsBitSet(15) ^ Registers.CarryFlag;
 
                 return result;
             }
@@ -2764,11 +2786,12 @@ namespace MBBSEmu.CPU
 
             unchecked
             {
-                if (addCarry && Registers.CarryFlag)
-                    source++;
+                var carryIn = addCarry && Registers.CarryFlag ? 1 : 0;
+                var wideResult = destination + source + carryIn;
+                var result = (byte)wideResult;
 
-                var result = (byte)(source + destination);
-                Flags_EvaluateCarry(EnumArithmeticOperation.Addition, result, destination, source);
+                Registers.CarryFlag = wideResult > byte.MaxValue;
+                Registers.AuxiliaryCarryFlag = (((source & 0xF) + (destination & 0xF) + carryIn) & 0x10) != 0;
                 Flags_EvaluateOverflow(EnumArithmeticOperation.Addition, result, destination, source);
                 Flags_EvaluateSignZero(result);
                 return result;
@@ -2783,11 +2806,11 @@ namespace MBBSEmu.CPU
 
             unchecked
             {
-                if (addCarry && Registers.CarryFlag)
-                    source++;
+                var carryIn = addCarry && Registers.CarryFlag ? 1 : 0;
+                var wideResult = destination + source + carryIn;
+                var result = (ushort)wideResult;
 
-                var result = (ushort)(source + destination);
-                Flags_EvaluateCarry(EnumArithmeticOperation.Addition, result, destination, source);
+                Registers.CarryFlag = wideResult > ushort.MaxValue;
                 Flags_EvaluateOverflow(EnumArithmeticOperation.Addition, result, destination, source);
                 Flags_EvaluateSignZero(result);
                 return result;
@@ -2795,18 +2818,18 @@ namespace MBBSEmu.CPU
         }
 
         [MethodImpl(OpcodeSubroutineCompilerOptimizations)]
-        private ushort Op_Add_32(bool addCarry)
+        private uint Op_Add_32(bool addCarry)
         {
             var destination = GetOperandValueUInt32(_currentInstruction.Op0Kind, EnumOperandType.Destination);
             var source = GetOperandValueUInt32(_currentInstruction.Op1Kind, EnumOperandType.Source);
 
             unchecked
             {
-                if (addCarry && Registers.CarryFlag)
-                    source++;
+                var carryIn = addCarry && Registers.CarryFlag ? 1u : 0u;
+                var wideResult = (ulong)destination + source + carryIn;
+                var result = (uint)wideResult;
 
-                var result = (ushort)(source + destination);
-                Flags_EvaluateCarry(EnumArithmeticOperation.Addition, result, destination, source);
+                Registers.CarryFlag = wideResult > uint.MaxValue;
                 Flags_EvaluateOverflow(EnumArithmeticOperation.Addition, result, destination, source);
                 Flags_EvaluateSignZero(result);
                 return result;
@@ -2887,9 +2910,10 @@ namespace MBBSEmu.CPU
         [MethodImpl(OpcodeSubroutineCompilerOptimizations)]
         private void Op_Imul_1operand_32()
         {
-            var operand2 = Registers.EAX;
+            // Get the value from EAX and the operand, ensuring they are sign-extended properly
+            var operand2 = (int)Registers.EAX;
             var operand3 = GetOperandValueInt32(_currentInstruction.Op0Kind, EnumOperandType.Destination);
-            long result = operand2 * operand3;
+            long result = (long)operand2 * operand3;
 
 
             //EDX is High 32-bits, EAX is low 32-bits
@@ -2897,7 +2921,7 @@ namespace MBBSEmu.CPU
             Registers.EAX = (uint)(result & 0xFFFFFFFF);
 
             //Set CarryFlag and OverflowFlag if the result is too large to fit in the destination
-            Registers.OverflowFlag = Registers.CarryFlag = Register.EDX != 0;
+            Registers.OverflowFlag = Registers.CarryFlag = (long)(int)Registers.EAX != result;
         }
 
         [MethodImpl(OpcodeSubroutineCompilerOptimizations)]
@@ -3435,7 +3459,7 @@ namespace MBBSEmu.CPU
                 _ => throw new Exception("Unsupported Operation Size")
             };
 
-            var result = (ushort)~destination;
+            var result = ~destination;
 
             WriteToDestination(result);
         }
@@ -4643,7 +4667,7 @@ namespace MBBSEmu.CPU
 
             //Only evaluate Overflow on Shift of 1 Bit, otherwise it's clear
             if (count == 1)
-                Flags_EvaluateOverflow(EnumArithmeticOperation.Subtraction, result, destination, source);
+                Flags_EvaluateOverflow(EnumArithmeticOperation.ShiftLeft, result, destination, count);
             else
                 Registers.OverflowFlag = false;
 
@@ -4681,7 +4705,7 @@ namespace MBBSEmu.CPU
             // only set AF flag on 8 bit additions, though technically it should be on 16/32 as well
             if (arithmeticOperation == EnumArithmeticOperation.Addition)
             {
-                Registers.AuxiliaryCarryFlag = ((((source & 0xF) + (destination & 0xF))) & 0xFF00) != 0;
+                Registers.AuxiliaryCarryFlag = ((((source & 0xF) + (destination & 0xF))) & 0x10) != 0;
             }
         }
 

--- a/MBBSEmu/CPU/RegistersStructs.cs
+++ b/MBBSEmu/CPU/RegistersStructs.cs
@@ -67,7 +67,8 @@ namespace MBBSEmu.CPU
                 _ => throw new Exception($"Unsupported FPU Register: {register}")
             };
 
-            return GetStackTop() - registerOffset;
+            //Wrap around the circular 8-slot stack instead of going negative
+            return (GetStackTop() - registerOffset) & 0x7;
         }
 
         public void PopStackTop()


### PR DESCRIPTION
Corrects several correctness bugs in the CPU emulation core:

- ADD/ADC/NOT (32-bit): results were truncated through (ushort), discarding the upper 16 bits of any 32-bit ADD/ADC/NOT.
- ADC/SBB (8/16/32-bit): carry/borrow-in was folded into the narrow source operand before flag evaluation, silently wrapping (and corrupting CF) whenever source was already the type's max value.
- RCL/RCR (8/16-bit): rotate count was never masked to 5 bits or reduced modulo (width+1), so counts above 31 (e.g. via CL) rotated the wrong number of times.
- RCL (16-bit): overflow flag checked bit 7 instead of bit 15.
- IMUL (32-bit, 1-operand): EAX was multiplied as unsigned instead of sign-extended, and CF/OF compared against the wrong symbol (Register.EDX, an enum constant, instead of Registers.EDX), making the flags always true.
- Flags_EvaluateCarry (8-bit): auxiliary carry (AF) nibble-overflow mask was wrong, so AF never actually set.
- SHLD (32-bit): overflow flag used an unrelated subtraction-based formula instead of the shift-count-based one.
- FpuRegistersStruct.GetStackPointer: circular 8-slot FPU stack index could go negative and throw IndexOutOfRangeException.

Adds/extends unit tests (including new NOT_Tests.cs and SBB_Tests.cs) covering each fix; each new test was verified to fail against the pre-fix code.