### PR TITLE
Render MajorMUD's DC1-DC4 as CP437 display glyphs

### DIFF
--- a/MBBSEmu.Tests/TextEncoding/CP437ConverterTests.cs
+++ b/MBBSEmu.Tests/TextEncoding/CP437ConverterTests.cs
@@ -22,8 +22,9 @@ namespace MBBSEmu.Tests.TextEncoding
         [Fact]
         public void ConvertToUtf8_ControlCodes_PassThroughUnchanged()
         {
-            // All C0 control codes pass through as-is (not converted to CP437 glyphs)
-            byte[] input = { 0x00, 0x01, 0x07, 0x08, 0x09, 0x0A, 0x0D, 0x11, 0x13, 0x1B };
+            // Genuine C0 control codes pass through as-is. DC1-DC4 (0x11-0x14) are the
+            // exception - they are converted to CP437 display glyphs (see the DC1-DC4 test).
+            byte[] input = { 0x00, 0x01, 0x07, 0x08, 0x09, 0x0A, 0x0D, 0x1B };
             var result = CP437Converter.ConvertToUtf8(input);
 
             result.Should().BeEquivalentTo(input);
@@ -32,13 +33,25 @@ namespace MBBSEmu.Tests.TextEncoding
         [Fact]
         public void ConvertToUtf8_AllLowBytes_PassThroughUnchanged()
         {
-            // Entire 0x00-0x1F range should pass through as control codes
-            var input = new byte[0x20];
-            for (byte i = 0; i < 0x20; i++)
-                input[i] = i;
+            // Every C0 control code except DC1-DC4 (0x11-0x14) passes through unchanged;
+            // DC1-DC4 convert to display glyphs and are covered separately.
+            byte[] input = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+                             0x10, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F };
 
             var result = CP437Converter.ConvertToUtf8(input);
-            result.Should().BeEquivalentTo(input);
+            result.Should().Equal(input);
+        }
+
+        [Fact]
+        public void ConvertToUtf8_Dc1ThroughDc4_ConvertToDisplayGlyphs()
+        {
+            // DC1-DC4 (0x11-0x14) are CP437 display glyphs, not control codes, for the
+            // modules that emit them (e.g. MajorMUD's full-screen editor): ◄ ↕ ‼ ¶.
+            byte[] input = { 0x11, 0x12, 0x13, 0x14 };
+            var result = CP437Converter.ConvertToUtf8(input);
+
+            var expected = Encoding.UTF8.GetBytes("◄↕‼¶"); // ◄ ↕ ‼ ¶
+            result.Should().Equal(expected);
         }
 
         [Fact]

--- a/MBBSEmu/TextEncoding/CP437Converter.cs
+++ b/MBBSEmu/TextEncoding/CP437Converter.cs
@@ -48,6 +48,16 @@ namespace MBBSEmu.TextEncoding
         };
 
         /// <summary>
+        ///     CP437 display glyphs for DC1-DC4 (0x11-0x14): ◄ ↕ ‼ ¶. Unlike the other C0
+        ///     control codes, these are drawn as glyphs by the modules that emit them
+        ///     (e.g. MajorMUD's full-screen editor), so ConvertToUtf8 renders them.
+        /// </summary>
+        private const byte FirstGlyphControl = 0x11;
+        private const byte LastGlyphControl = 0x14;
+
+        private static readonly ushort[] GlyphControlToUnicode = { 0x25C4, 0x2195, 0x203C, 0x00B6 };
+
+        /// <summary>
         ///     Per-byte UTF-8 encoding of <see cref="CP437ToUnicode"/>, built once at type
         ///     initialization. The telnet send path converts every outbound write, so encoding
         ///     each extended byte on demand would allocate a char[] and a byte[] per character.
@@ -62,8 +72,21 @@ namespace MBBSEmu.TextEncoding
             for (var i = 0; i < table.Length; i++)
                 table[i] = Encoding.UTF8.GetBytes(new[] { (char)CP437ToUnicode[i] });
 
+            // CP437ToUnicode maps DC1-DC4 to the C0 control codes, which is the right
+            // answer for every other consumer of the table. Override just those four with
+            // their display glyphs so ConvertToUtf8 stays a single table lookup.
+            for (var b = FirstGlyphControl; b <= LastGlyphControl; b++)
+                table[b] = Encoding.UTF8.GetBytes(new[] { (char)GlyphControlToUnicode[b - FirstGlyphControl] });
+
             return table;
         }
+
+        /// <summary>
+        ///     True for the DC1-DC4 bytes that render as CP437 display glyphs rather than
+        ///     passing through as control codes. Kept as a single predicate so the length
+        ///     pass and the write pass below cannot disagree about the output size.
+        /// </summary>
+        private static bool IsGlyphControl(byte b) => b >= FirstGlyphControl && b <= LastGlyphControl;
 
         /// <summary>
         ///     Converts CP437 bytes to UTF-8 encoded bytes.
@@ -71,9 +94,15 @@ namespace MBBSEmu.TextEncoding
         ///     Standard ASCII (0x20-0x7E) passes through unchanged.
         ///     Extended ASCII (0x80-0xFF) is converted to multi-byte UTF-8 sequences.
         ///
-        ///     Low bytes are not converted to CP437 glyphs because BBS modules commonly
-        ///     use them as control/formatting markers over telnet connections, not as
-        ///     display characters. See issue #49 (T-LORD) for context.
+        ///     Low bytes other than DC1-DC4 are not converted to CP437 glyphs because BBS
+        ///     modules commonly use them as control/formatting markers over telnet
+        ///     connections, not as display characters. See issue #49 (T-LORD) for context.
+        ///
+        ///     DC1-DC4 are the exception: modules that use those byte values as screen-pause
+        ///     markers register them through GSBL's btupbc/btucpc, and SessionBase consumes
+        ///     the registered markers before output reaches this converter. What survives to
+        ///     here is display content, so rendering it as glyphs is safe. See
+        ///     docs/reverse-engineering/tlord-screen-pause.md.
         /// </summary>
         /// <param name="cp437Bytes">Input bytes in CP437 encoding</param>
         /// <returns>UTF-8 encoded bytes</returns>
@@ -84,14 +113,14 @@ namespace MBBSEmu.TextEncoding
             var length = 0;
 
             foreach (var b in cp437Bytes)
-                length += b < 0x80 ? 1 : CP437ToUtf8[b].Length;
+                length += b < 0x80 && !IsGlyphControl(b) ? 1 : CP437ToUtf8[b].Length;
 
             var result = new byte[length];
             var offset = 0;
 
             foreach (var b in cp437Bytes)
             {
-                if (b < 0x80)
+                if (b < 0x80 && !IsGlyphControl(b))
                 {
                     // ASCII + control chars (0x00-0x7F) - pass through unchanged
                     result[offset++] = b;


### PR DESCRIPTION
> **Must not merge before #664.** #652 has merged, so this is now rebased onto `master` and carries only its own commit — 2 files, +54/-12. #664 remains a correctness prerequisite rather than a code one: it consumes T-LORD's screen-pause markers host-side before output reaches the converter, so merging this without it would render T-LORD's embedded `0x13` as `‼` — the regression documented in #49. git reports the two as conflict-free, so nothing enforces this but the note.

## What

MajorMUD's full-screen editor draws its line and arrow layout with CP437 display glyphs in the DC1–DC4 range (0x11–0x14 → ◄ ↕ ‼ ¶). When CP437→UTF-8 conversion is enabled, those bytes must render as their Unicode glyphs rather than pass through raw. Fixes #553.

<img width="605" height="351" alt="image" src="https://github.com/user-attachments/assets/34307545-6566-4434-acf9-7879d5e41f83" />

## Change

`CP437Converter.ConvertToUtf8` renders 0x11–0x14 as ◄ ↕ ‼ ¶. Every other C0 control code still passes through unchanged.

The four glyph encodings are folded into the precomputed UTF-8 table #652 builds, overriding those control-code entries, so conversion stays a single table lookup with no branch added to the hot path. The length pass and the write pass share one `IsGlyphControl` predicate, since they must agree on the output size. The method's XML doc records the narrowed contract and why the exception is safe.

This depends on #664, which removes the blanket DC1–DC4 `SessionBase` filter safely — the host arms and consumes the screen-pause markers in ASCII-mode output, while full-screen (FSD) binary-mode output such as MajorMUD's passes them through as glyphs. With the filter gone at the base, this PR is only the glyph rendering.

## Verification

- `CP437ConverterTests`: 0x11–0x14 convert to the four glyphs; the passthrough tests are updated to exclude the now-converted bytes. Full converter suite green.
- The end-to-end guard for the glyph path lives in #664's wire-invariant tests: MajorMUD's FSD character worksheet keeps its glyph bytes on the wire.


