### PR TITLE
Fix SAR sign fill for shift counts greater than 1

### DIFF
--- a/MBBSEmu.Tests/CPU/SAR_Tests.cs
+++ b/MBBSEmu.Tests/CPU/SAR_Tests.cs
@@ -1,0 +1,101 @@
+using Iced.Intel;
+using Xunit;
+using static Iced.Intel.AssemblerRegisters;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class SAR_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(0x8000, 0xC000, false)] // sign fills bit 14
+        [InlineData(0x0004, 0x0002, false)]
+        [InlineData(0x0005, 0x0002, true)]
+        [InlineData(0xFFFF, 0xFFFF, true)]
+        public void SAR_AX_1(ushort axValue, ushort axExpectedValue, bool carry)
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.AX = axValue;
+
+            var instructions = new Assembler(16);
+            instructions.sar(ax, 1);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(axExpectedValue, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(carry, mbbsEmuCpuRegisters.CarryFlag);
+            //SAR by 1 always clears OF
+            Assert.False(mbbsEmuCpuRegisters.OverflowFlag);
+            Assert.Equal(axExpectedValue >= 0x8000, mbbsEmuCpuRegisters.SignFlag);
+        }
+
+        [Theory]
+        [InlineData(0x91A0, 2, 0xE468, false)] // every vacated bit sign-filled, not just bit 15
+        [InlineData(0xFFFF, 4, 0xFFFF, true)]
+        [InlineData(0x8000, 15, 0xFFFF, false)]
+        [InlineData(0x8000, 16, 0xFFFF, true)] // fully shifted out: all sign bits, CF = old bit 15
+        [InlineData(0x7FFF, 4, 0x07FF, true)] // positive operands keep logical behavior
+        [InlineData(0x0100, 8, 0x0001, false)]
+        public void SAR_AX_MultiBit(ushort axValue, byte count, ushort axExpectedValue, bool carry)
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.AX = axValue;
+
+            var instructions = new Assembler(16);
+            instructions.sar(ax, count);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(axExpectedValue, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(carry, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(axExpectedValue >= 0x8000, mbbsEmuCpuRegisters.SignFlag);
+            Assert.Equal(axExpectedValue == 0, mbbsEmuCpuRegisters.ZeroFlag);
+        }
+
+        [Theory]
+        [InlineData(0xA0, 2, 0xE8, false)]
+        [InlineData(0x81, 1, 0xC0, true)]
+        [InlineData(0xFF, 8, 0xFF, true)] // fully shifted out: all sign bits, CF = old bit 7
+        [InlineData(0x7F, 3, 0x0F, true)]
+        [InlineData(0x01, 1, 0x00, true)]
+        public void SAR_AL_MultiBit(byte alValue, byte count, byte alExpectedValue, bool carry)
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.AL = alValue;
+
+            var instructions = new Assembler(16);
+            instructions.sar(al, count);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(alExpectedValue, mbbsEmuCpuRegisters.AL);
+            Assert.Equal(carry, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(alExpectedValue >= 0x80, mbbsEmuCpuRegisters.SignFlag);
+            Assert.Equal(alExpectedValue == 0, mbbsEmuCpuRegisters.ZeroFlag);
+        }
+
+        [Fact]
+        public void SAR_AX_Big_Shift()
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.AX = 0xF000;
+
+            var instructions = new Assembler(16);
+            instructions.sar(ax, 35); // will clamp to 3
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(0xFE00, mbbsEmuCpuRegisters.AX);
+            Assert.False(mbbsEmuCpuRegisters.CarryFlag);
+            Assert.True(mbbsEmuCpuRegisters.SignFlag);
+            Assert.False(mbbsEmuCpuRegisters.ZeroFlag);
+        }
+    }
+}

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -1914,14 +1914,13 @@ namespace MBBSEmu.CPU
             {
                 // in order to inspect bits lost during shift when computing the carry flag, we
                 // extend the size of the operation first by shifting left and then shifting right.
-                // So result becomes 0xDDLL where DD is the value and LL are the lost bits
-                var uresult = (ushort)((destination << 8) >> source);
-                Flags_EvaluateCarry(EnumArithmeticOperation.ShiftArithmeticRight, (byte)(uresult & 0x80));
+                // So result becomes 0xDDLL where DD is the value and LL are the lost bits.
+                // The container is sign-extended so the right shift is arithmetic and fills
+                // every vacated bit with the sign bit, as SAR requires for any count
+                var sresult = ((int)(sbyte)destination << 8) >> source;
+                Flags_EvaluateCarry(EnumArithmeticOperation.ShiftArithmeticRight, (byte)(sresult & 0x80));
 
-                var result = (byte)(uresult >> 8);
-                // maintain sign bit
-                if (destination.IsNegative())
-                    result |= 0x80;
+                var result = (byte)((uint)sresult >> 8);
 
                 Flags_EvaluateOverflow(EnumArithmeticOperation.ShiftArithmeticRight, result, destination, source);
                 Flags_EvaluateSignZero(result);
@@ -1941,14 +1940,13 @@ namespace MBBSEmu.CPU
             {
                 // in order to inspect bits lost during shift when computing the carry flag, we
                 // extend the size of the operation first by shifting left and then shifting right.
-                // So result becomes 0xDDDDLLLL where DDDD is the value and LLLL are the lost bits
-                var uresult = ((uint)destination << 16) >> source;
-                Flags_EvaluateCarry(EnumArithmeticOperation.ShiftArithmeticRight, (ushort)(uresult & 0x8000));
+                // So result becomes 0xDDDDLLLL where DDDD is the value and LLLL are the lost bits.
+                // The container is sign-extended so the right shift is arithmetic and fills
+                // every vacated bit with the sign bit, as SAR requires for any count
+                var sresult = ((int)(short)destination << 16) >> source;
+                Flags_EvaluateCarry(EnumArithmeticOperation.ShiftArithmeticRight, (ushort)(sresult & 0x8000));
 
-                var result = (ushort)(uresult >> 16);
-                // maintain sign bit
-                if (destination.IsNegative())
-                    result |= 0x8000;
+                var result = (ushort)((uint)sresult >> 16);
 
                 Flags_EvaluateOverflow(EnumArithmeticOperation.ShiftArithmeticRight, result, destination, source);
                 Flags_EvaluateSignZero(result);


### PR DESCRIPTION
Fixes item 1 of #668.

**Root cause.** `Op_Sar_8` and `Op_Sar_16` implement SAR as a logical shift followed by ORing back only the top bit (`if (destination.IsNegative()) result |= 0x8000;`). For counts greater than 1 on negative operands, every vacated bit except the top one is filled with 0 instead of the sign: `sar 0x91A0, 2` produced 0xA468 where hardware gives 0xE468. Correct only for count == 1, so any module doing arithmetic right-shifts on negative quantities (division by powers of two, fixed-point math) silently computes wrong values.

**The change.** The shifted container is now sign-extended (`(int)(sbyte)` / `(int)(short)`) so the right shift itself is arithmetic and fills every vacated bit with the sign, for any count. The lost-bits carry inspection is unchanged and produces the same CF as before; positive operands behave identically. This also corrects the count ≥ width case: `sar 0x8000, 16` now gives 0xFFFF (previously 0x8000).

**Verification.** New `SAR_Tests.cs` — there was none, which is how this survived — with 16 cases across 8- and 16-bit operands: the repro above, sign-fill at counts 2/4/8/15/16, positive operands, CF/SF/ZF assertions throughout, OF on the count-1 path, and the count-clamp case, following the `SHR_Tests` conventions. The full test suite passes apart from two `dcdate_Tests` cases that fail identically on unmodified master.
