### PR TITLE
Implement the ROL instruction

### DIFF
--- a/MBBSEmu.Tests/CPU/ROL_Tests.cs
+++ b/MBBSEmu.Tests/CPU/ROL_Tests.cs
@@ -1,0 +1,148 @@
+using Iced.Intel;
+using Xunit;
+using static Iced.Intel.AssemblerRegisters;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class ROL_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(0x8000, 0x0001, true, true)] // MSB wraps to LSB; OF = MSB(result) != CF
+        [InlineData(0x4000, 0x8000, false, true)]
+        [InlineData(0x2000, 0x4000, false, false)]
+        [InlineData(0x0001, 0x0002, false, false)]
+        public void ROL_AX_1(ushort axValue, ushort axExpectedValue, bool carry, bool overflow)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AX = axValue;
+
+            var instructions = new Assembler(16);
+            instructions.rol(ax, 1);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(axExpectedValue, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(carry, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(overflow, mbbsEmuCpuRegisters.OverflowFlag);
+        }
+
+        [Theory]
+        [InlineData(0x8001, 4, 0x0018, false)]
+        [InlineData(0xC000, 2, 0x0003, true)]
+        [InlineData(0xAAAA, 8, 0xAAAA, false)]
+        [InlineData(0x0001, 16, 0x0001, true)] // full rotation is identity; CF = LSB of result
+        public void ROL_AX_MultiBit(ushort axValue, byte count, ushort axExpectedValue, bool carry)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AX = axValue;
+
+            var instructions = new Assembler(16);
+            instructions.rol(ax, count);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(axExpectedValue, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(carry, mbbsEmuCpuRegisters.CarryFlag);
+        }
+
+        [Theory]
+        [InlineData(0x80, 1, 0x01, true, true)]
+        [InlineData(0x01, 1, 0x02, false, false)]
+        public void ROL_AL_1(byte alValue, byte count, byte alExpectedValue, bool carry, bool overflow)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AL = alValue;
+
+            var instructions = new Assembler(16);
+            instructions.rol(al, count);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(alExpectedValue, mbbsEmuCpuRegisters.AL);
+            Assert.Equal(carry, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(overflow, mbbsEmuCpuRegisters.OverflowFlag);
+        }
+
+        [Theory]
+        [InlineData(0x81, 4, 0x18, false)]
+        [InlineData(0xC0, 2, 0x03, true)]
+        public void ROL_AL_MultiBit(byte alValue, byte count, byte alExpectedValue, bool carry)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AL = alValue;
+
+            var instructions = new Assembler(16);
+            instructions.rol(al, count);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(alExpectedValue, mbbsEmuCpuRegisters.AL);
+            Assert.Equal(carry, mbbsEmuCpuRegisters.CarryFlag);
+        }
+
+        [Theory]
+        [InlineData(0x81, 9, 0x03, true)] // count masked to 5 bits, then mod 8: 9 ≡ 1
+        [InlineData(0x81, 8, 0x81, true)] // full width: identity, CF = LSB of result
+        [InlineData(0x80, 33, 0x01, true)] // 33 & 0x1F = 1
+        public void ROL_AL_CL(byte alValue, byte clValue, byte alExpectedValue, bool carry)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AL = alValue;
+            mbbsEmuCpuRegisters.CL = clValue;
+
+            var instructions = new Assembler(16);
+            instructions.rol(al, cl);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(alExpectedValue, mbbsEmuCpuRegisters.AL);
+            Assert.Equal(carry, mbbsEmuCpuRegisters.CarryFlag);
+        }
+
+        [Theory]
+        [InlineData(0x0001, 17, 0x0002, false)] // 17 ≡ 1 mod 16
+        [InlineData(0x8000, 17, 0x0001, true)]
+        public void ROL_AX_CL(ushort axValue, byte clValue, ushort axExpectedValue, bool carry)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AX = axValue;
+            mbbsEmuCpuRegisters.CL = clValue;
+
+            var instructions = new Assembler(16);
+            instructions.rol(ax, cl);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(axExpectedValue, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(carry, mbbsEmuCpuRegisters.CarryFlag);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(32)] // masks to 0
+        public void ROL_AX_CL_MaskedZeroCount_LeavesValueAndFlags(byte clValue)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AX = 0x8001;
+            mbbsEmuCpuRegisters.CL = clValue;
+            mbbsEmuCpuRegisters.CarryFlag = true;
+            mbbsEmuCpuRegisters.OverflowFlag = true;
+
+            var instructions = new Assembler(16);
+            instructions.rol(ax, cl);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(0x8001, mbbsEmuCpuRegisters.AX);
+            Assert.True(mbbsEmuCpuRegisters.CarryFlag);
+            Assert.True(mbbsEmuCpuRegisters.OverflowFlag);
+        }
+    }
+}

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -733,6 +733,9 @@ namespace MBBSEmu.CPU
                 case Mnemonic.Ror:
                     Op_Ror();
                     break;
+                case Mnemonic.Rol:
+                    Op_Rol();
+                    break;
                 case Mnemonic.Ftst:
                     Op_Ftst();
                     break;
@@ -4226,6 +4229,88 @@ namespace MBBSEmu.CPU
         private void Op_Frndint()
         {
             FpuStack[Registers.Fpu.GetStackTop()] = Math.Round(FpuStack[Registers.Fpu.GetStackTop()], Registers.Fpu.GetRoundingControl());
+        }
+
+        /// <summary>
+        ///     Rotate Left
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Rol()
+        {
+            var result = _currentOperationSize switch
+            {
+                1 => Op_Rol_8(),
+                2 => Op_Rol_16(),
+                _ => throw new Exception("Unsupported Operation Size")
+            };
+
+            WriteToDestination(result);
+        }
+
+        /// <summary>
+        ///     8-bit Rotate Left
+        /// </summary>
+        [MethodImpl(OpcodeSubroutineCompilerOptimizations)]
+        private byte Op_Rol_8()
+        {
+            var destination = GetOperandValueUInt8(_currentInstruction.Op0Kind, EnumOperandType.Destination);
+            var source = GetOperandValueUInt8(_currentInstruction.Op1Kind, EnumOperandType.Source);
+
+            //286+ masks the count to 5 bits; a masked count of 0 leaves the
+            //destination and all flags untouched
+            source &= 0x1F;
+            if (source == 0)
+                return destination;
+
+            unchecked
+            {
+                //rotation is modulo the operand width; a multiple of the width
+                //(count 8, 16, 24) is the identity but still updates CF below
+                var rotate = source % 8;
+                var result = (byte)((destination << rotate) | (destination >> (8 - rotate)));
+
+                //CF Set if Least Significant Bit set to 1 (the bit rotated out of the top)
+                Registers.CarryFlag = result.IsBitSet(0);
+
+                //If the Most Significant Bit and CF are not the same, then we overflowed for 1 bit rotations
+                if (source == 1)
+                    Registers.OverflowFlag = result.IsBitSet(7) != Registers.CarryFlag;
+
+                return result;
+            }
+        }
+
+        /// <summary>
+        ///     16-bit Rotate Left
+        /// </summary>
+        [MethodImpl(OpcodeSubroutineCompilerOptimizations)]
+        private ushort Op_Rol_16()
+        {
+            var destination = GetOperandValueUInt16(_currentInstruction.Op0Kind, EnumOperandType.Destination);
+            var source = GetOperandValueUInt16(_currentInstruction.Op1Kind, EnumOperandType.Source);
+
+            //286+ masks the count to 5 bits; a masked count of 0 leaves the
+            //destination and all flags untouched
+            source &= 0x1F;
+            if (source == 0)
+                return destination;
+
+            unchecked
+            {
+                //rotation is modulo the operand width; a multiple of the width
+                //(count 16) is the identity but still updates CF below
+                var rotate = source % 16;
+                var result = (ushort)((destination << rotate) | (destination >> (16 - rotate)));
+
+                //CF Set if Least Significant Bit set to 1 (the bit rotated out of the top)
+                Registers.CarryFlag = result.IsBitSet(0);
+
+                //If the Most Significant Bit and CF are not the same, then we overflowed for 1 bit rotations
+                if (source == 1)
+                    Registers.OverflowFlag = result.IsBitSet(15) != Registers.CarryFlag;
+
+                return result;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes item 2 of #668.

ROL was the one rotate/shift with no implementation — `Tick()` has cases for SHL/SHR/SAR/ROR/RCL/RCR/SHLD, so any module executing a ROL dies with `Unsupported OpCode: Rol`.

**The change.** `Op_Rol`/`Op_Rol_8`/`Op_Rol_16`, structured after the existing `Op_Ror` family: same operand handling, same flag conventions. CF gets the bit rotated out of the top (the LSB of the result), and OF is evaluated for 1-bit rotations as MSB(result) != CF, per the 8086 rules ROR already follows.

Count handling follows the 286+ rules the shift handlers already use (`source &= 0x1F`), then rotates modulo the operand width: `rol al, cl` with CL=9 rotates by 1, CL=8 is the identity with CF = LSB of the result, and a masked count of 0 (CL=0 or CL=32) leaves the destination and all flags untouched. Note `Op_Ror` predates this and still wraps incorrectly for counts above the width — left as is here to keep this PR additive; can follow up separately.

**Verification.** New `ROL_Tests.cs` with 19 cases across 8- and 16-bit operands: 1-bit rotations with CF/OF assertions (both OF polarities), multi-bit and full-width rotations, `cl`-register forms at counts 0, 8, 9, 17, 32, and 33, and flag preservation at masked count 0. The full test suite passes apart from the two `dcdate_Tests` cases that fail identically on unmodified master (also noted on #669).
