### PR TITLE
Implement the 32-bit SBB operand path

### DIFF
--- a/MBBSEmu.Tests/CPU/SBB_Tests.cs
+++ b/MBBSEmu.Tests/CPU/SBB_Tests.cs
@@ -69,13 +69,19 @@ namespace MBBSEmu.Tests.CPU
         }
 
         [Theory]
-        [InlineData(0x00000005u, 0x00000003u, false, 0x00000002u, false)] // Simple subtraction, no borrow-in
-        [InlineData(0x00000005u, 0x00000003u, true, 0x00000001u, false)] // Borrow-in, no resulting borrow
-        [InlineData(0x00000000u, 0x00000000u, true, 0xFFFFFFFFu, true)] // Borrow-in on zero operands must borrow
-        [InlineData(0x00010000u, 0x00000001u, false, 0x0000FFFFu, false)] // Borrow across the low word
-        [InlineData(0x00000000u, 0x00000001u, false, 0xFFFFFFFFu, true)] // Plain underflow
+        //                eax          ebx          carry-in  expected     OF     SF     ZF     CF
+        [InlineData(0x00000005u, 0x00000003u, false, 0x00000002u, false, false, false, false)] // Simple subtraction, no borrow-in
+        [InlineData(0x00000005u, 0x00000003u, true, 0x00000001u, false, false, false, false)] // Borrow-in, no resulting borrow
+        [InlineData(0x00000005u, 0x00000005u, false, 0x00000000u, false, false, true, false)] // Equal operands zero the result
+        [InlineData(0x00000000u, 0x00000000u, true, 0xFFFFFFFFu, false, true, false, true)] // Borrow-in on zero operands must borrow
+        [InlineData(0x00010000u, 0x00000001u, false, 0x0000FFFFu, false, false, false, false)] // Borrow across the low word
+        [InlineData(0x00000000u, 0x00000001u, false, 0xFFFFFFFFu, false, true, false, true)] // Plain underflow
+        [InlineData(0x80000000u, 0x00000001u, false, 0x7FFFFFFFu, true, false, false, false)] // Signed underflow past INT_MIN sets OF, not CF
+        [InlineData(0x7FFFFFFFu, 0xFFFFFFFFu, false, 0x80000000u, true, true, false, true)] // Signed overflow past INT_MAX sets both OF and CF
+        [InlineData(0x80000000u, 0x00000000u, true, 0x7FFFFFFFu, true, false, false, false)] // OF must account for the borrow-in: INT_MIN - 0 - 1 overflows
         public void SBB_EAX_EBX_32Bit(uint eaxValue, uint ebxValue, bool initialCarryFlag,
-            uint expectedValue, bool expectedCarryFlag)
+            uint expectedValue, bool overflowFlagValue, bool signFlagValue, bool zeroFlagValue,
+            bool carryFlagValue)
         {
             Reset();
             mbbsEmuCpuRegisters.EAX = eaxValue;
@@ -89,7 +95,10 @@ namespace MBBSEmu.Tests.CPU
             mbbsEmuCpuCore.Tick();
 
             Assert.Equal(expectedValue, mbbsEmuCpuRegisters.EAX);
-            Assert.Equal(expectedCarryFlag, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(overflowFlagValue, mbbsEmuCpuRegisters.OverflowFlag);
+            Assert.Equal(signFlagValue, mbbsEmuCpuRegisters.SignFlag);
+            Assert.Equal(zeroFlagValue, mbbsEmuCpuRegisters.ZeroFlag);
+            Assert.Equal(carryFlagValue, mbbsEmuCpuRegisters.CarryFlag);
         }
 
         [Fact]

--- a/MBBSEmu.Tests/CPU/SBB_Tests.cs
+++ b/MBBSEmu.Tests/CPU/SBB_Tests.cs
@@ -1,6 +1,8 @@
+using Iced.Intel;
 using MBBSEmu.CPU;
 using MBBSEmu.Extensions;
 using Xunit;
+using static Iced.Intel.AssemblerRegisters;
 
 namespace MBBSEmu.Tests.CPU
 {
@@ -62,6 +64,52 @@ namespace MBBSEmu.Tests.CPU
 
             //Verify Results: 0x0000 - 0xFFFF - 1 == -65536, which is congruent to 0x0000 (mod 65536), and a borrow occurred
             Assert.Equal(0x0000, mbbsEmuCpuRegisters.AX);
+            Assert.True(mbbsEmuCpuRegisters.CarryFlag);
+            Assert.True(mbbsEmuCpuRegisters.ZeroFlag);
+        }
+
+        [Theory]
+        [InlineData(0x00000005u, 0x00000003u, false, 0x00000002u, false)] // Simple subtraction, no borrow-in
+        [InlineData(0x00000005u, 0x00000003u, true, 0x00000001u, false)] // Borrow-in, no resulting borrow
+        [InlineData(0x00000000u, 0x00000000u, true, 0xFFFFFFFFu, true)] // Borrow-in on zero operands must borrow
+        [InlineData(0x00010000u, 0x00000001u, false, 0x0000FFFFu, false)] // Borrow across the low word
+        [InlineData(0x00000000u, 0x00000001u, false, 0xFFFFFFFFu, true)] // Plain underflow
+        public void SBB_EAX_EBX_32Bit(uint eaxValue, uint ebxValue, bool initialCarryFlag,
+            uint expectedValue, bool expectedCarryFlag)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.EAX = eaxValue;
+            mbbsEmuCpuRegisters.EBX = ebxValue;
+            mbbsEmuCpuRegisters.CarryFlag = initialCarryFlag;
+
+            var instructions = new Assembler(16);
+            instructions.sbb(eax, ebx);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(expectedValue, mbbsEmuCpuRegisters.EAX);
+            Assert.Equal(expectedCarryFlag, mbbsEmuCpuRegisters.CarryFlag);
+        }
+
+        [Fact]
+        public void SBB_EAX_EBX_SourceMaxValueWithBorrowIn_DoesNotWrapCarryFlag()
+        {
+            Reset();
+            mbbsEmuCpuRegisters.EAX = 0x00000000;
+            mbbsEmuCpuRegisters.EBX = 0xFFFFFFFF;
+            mbbsEmuCpuRegisters.CarryFlag = true;
+
+            var instructions = new Assembler(16);
+            instructions.sbb(eax, ebx);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results: 0x00000000 - 0xFFFFFFFF - 1 == -4294967296, congruent to 0x00000000
+            //(mod 2^32), and a borrow occurred. Computing this in 32-bit arithmetic would wrap the
+            //subtrahend to zero and report no borrow.
+            Assert.Equal(0x00000000u, mbbsEmuCpuRegisters.EAX);
             Assert.True(mbbsEmuCpuRegisters.CarryFlag);
             Assert.True(mbbsEmuCpuRegisters.ZeroFlag);
         }

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -1600,6 +1600,7 @@ namespace MBBSEmu.CPU
             {
                 1 => Op_Sbb_8(),
                 2 => Op_Sbb_16(),
+                4 => Op_Sbb_32(),
                 _ => throw new Exception("Unsupported Operation Size")
             };
 
@@ -1635,6 +1636,26 @@ namespace MBBSEmu.CPU
                 var borrowIn = Registers.CarryFlag ? 1 : 0;
                 var wideResult = destination - source - borrowIn;
                 var result = (ushort)wideResult;
+
+                Registers.CarryFlag = wideResult < 0;
+                Flags_EvaluateOverflow(EnumArithmeticOperation.Subtraction, result, destination, source);
+                Flags_EvaluateSignZero(result);
+                return result;
+            }
+        }
+
+        [MethodImpl(OpcodeSubroutineCompilerOptimizations)]
+        private uint Op_Sbb_32()
+        {
+            var source = GetOperandValueUInt32(_currentInstruction.Op1Kind, EnumOperandType.Source);
+            var destination = GetOperandValueUInt32(_currentInstruction.Op0Kind, EnumOperandType.Destination);
+
+            unchecked
+            {
+                //Widened to long because uint arithmetic would wrap before the borrow can be observed
+                var borrowIn = Registers.CarryFlag ? 1L : 0L;
+                var wideResult = (long)destination - source - borrowIn;
+                var result = (uint)wideResult;
 
                 Registers.CarryFlag = wideResult < 0;
                 Flags_EvaluateOverflow(EnumArithmeticOperation.Subtraction, result, destination, source);


### PR DESCRIPTION
## Why

`SBB` with a 32-bit operand throws instead of executing. `Op_Sbb` dispatches on
`_currentOperationSize` but only handles the 1- and 2-byte cases, so any 32-bit guest
`SBB` — `sbb eax, ebx`, for example — falls through to
`throw new Exception("Unsupported Operation Size")` and kills the tick.

This is the gap left by #663, which fixed the borrow-in handling for the 8- and 16-bit paths.
That fix was correct and is unchanged here; the 32-bit path simply never existed to receive it.
`Op_Sub_32` has been present for the non-borrowing case all along, so the asymmetry is
specific to `SBB`.

## What changed

- `Op_Sbb_32` implements the 32-bit case, following `Op_Sbb_16` exactly: read both operands,
  subtract source and borrow-in, set carry from the borrow, then evaluate overflow and
  sign/zero.
- `Op_Sbb` gains the `4 => Op_Sbb_32()` dispatch arm.

The one deviation from the 8/16-bit siblings is the accumulator width. Those compute
`destination - source - borrowIn` in `int`, which is safe because `byte` and `ushort` both
promote. At 32 bits the same expression would wrap in `uint` before the borrow could be
observed — `0x00000000 - 0xFFFFFFFF - 1` would report no borrow — so the intermediate is
widened to `long` and carry is taken from its sign.

## Verification

`SBB_Tests` gains a 32-bit theory covering simple subtraction, borrow-in with and without a
resulting borrow, a borrow across the low word, plain underflow, signed underflow past
`INT_MIN`, and signed overflow past `INT_MAX`, plus a regression test for the
maximum-source-with-borrow-in case that motivated the `long` accumulator. The theory asserts
the overflow, sign, and zero flags alongside the result and carry, matching what the sibling
`SUB_R32_*` tests pin.

One row is worth calling out: `INT_MIN - 0 - 1` sets `OF` only because overflow is evaluated
on the post-borrow result. Evaluating it on `destination - source` instead fails that row,
and never setting `OF` fails three — both confirmed by mutation.

Reverting only the `CPUCore.cs` change fails the new cases with
`System.Exception : Unsupported Operation Size`, confirming they exercise the new path.
Full `SBB_Tests` suite: 15 passed; full `MBBSEmu.Tests.CPU` suite: 1057 passed.

## Follow-up

`SBB` is not alone. Ten of the nineteen size-dispatching opcode handlers on `master` have no
32-bit arm and throw the same way: `Op_Dec`, `Op_Neg`, `Op_Rcl`, `Op_Rcr`, `Op_Rol`, `Op_Ror`,
`Op_Sar`, `Op_Sbb`, `Op_Shr`, `Op_Xchg`. This PR covers only `SBB`, which is the one with a
reproduced failure. Happy to take the rest in a follow-up if that is wanted.

