### PR TITLE
Parse dcdate strings with the invariant culture

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/dcdate_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/dcdate_Tests.cs
@@ -1,6 +1,9 @@
 ﻿using MBBSEmu.Memory;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
+using System.Threading;
 using Xunit;
 
 namespace MBBSEmu.Tests.ExportedModules.Majorbbs
@@ -31,6 +34,39 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             Assert.Equal(expectedValue, mbbsEmuCpuRegisters.AX);
 
+        }
+
+        [Theory]
+        [InlineData("en-US")] //Month-first
+        [InlineData("en-GB")] //Day-first
+        [InlineData("en-IN")] //Day-first
+        [InlineData("de-DE")] //Day-first, dotted separators
+        public void DCDATE_IsIndependentOfHostCulture(string cultureName)
+        {
+            //Module date strings are always MM/DD/YY. A day-first host culture would read
+            //"12/31/90" as day 12 of month 31 and reject it, so the same input must decode
+            //identically no matter what the host is set to.
+            const string inputString = "12/31/90";
+            const ushort expectedValue = 5535;
+
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo(cultureName);
+
+                Reset();
+
+                var string1Pointer = mbbsEmuMemoryCore.AllocateVariable("STRING1", (ushort)(inputString.Length + 1));
+                mbbsEmuMemoryCore.SetArray("STRING1", Encoding.ASCII.GetBytes(inputString));
+
+                ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, DCDATE_ORDINAL, new List<FarPtr> { string1Pointer });
+
+                Assert.Equal(expectedValue, mbbsEmuCpuRegisters.AX);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
         }
     }
 }

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -7879,7 +7880,11 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             var inputDate = GetParameterString(0, true);
 
-            if (!DateTime.TryParse(inputDate, out var inputDateTime))
+            //Module date strings are always MM/DD/YY, so they must be parsed independently of the
+            //host's culture. Under a day-first culture (en-GB, en-IN, most of Europe) the current
+            //culture would read "12/31/90" as day 12 of month 31 and reject a valid date.
+            if (!DateTime.TryParse(inputDate, CultureInfo.InvariantCulture, DateTimeStyles.None,
+                    out var inputDateTime))
             {
                 Registers.AX = 0xFFFF;
                 return;


### PR DESCRIPTION
## Why

`dcdate` decodes a module-supplied date string into MajorBBS' packed
`YYYYYYYMMMMDDDDD` format. Module date strings are always `MM/DD/YY` — the method's own
doc comment says so — but the parse runs through `CultureInfo.CurrentCulture`:

```csharp
if (!DateTime.TryParse(inputDate, out var inputDateTime))
```

On a host whose culture is day-first — en-GB, en-IN, and most of Europe — `"12/31/90"` is
read as day 12 of month 31, which is not a date. `TryParse` returns false and `dcdate`
hands the module `0xFFFF`, its error value, for a perfectly valid input. A module that
checks that result will treat the date as unparseable; one that doesn't will use `0xFFFF`
as a packed date.

Only inputs that are ambiguous-safe survive. `"1/1/80"` parses identically under either
convention, which is why the existing tests pass on some machines and not others: on a
day-first host, `DCDATE_Test` fails the `09/17/20` and `12/31/90` cases and passes the
rest.

The emulator's job is to reproduce a DOS-era API whose date format is fixed, so the host's
regional settings should not be an input at all.

## What changed

`dcdate` parses with `CultureInfo.InvariantCulture` and `DateTimeStyles.None`. Invariant's
short-date pattern is month-first, matching the format modules actually send, and its
two-digit-year window resolves `90` to 1990, `20` to 2020, and `80` to 1980 — the values
the existing test expectations already encode.

Behaviour is unchanged on a month-first host. Genuinely invalid input such as `"13/32/00"`
still returns `0xFFFF`.

This is the only culture-sensitive date parse in `MBBSEmu/`.

## Verification

`dcdate_Tests` gains `DCDATE_IsIndependentOfHostCulture`, which pins
`Thread.CurrentThread.CurrentCulture` to en-US, en-GB, en-IN, and de-DE in turn and asserts
`"12/31/90"` decodes to the same value under each, restoring the original culture
afterward.

That test fails on the current code for the three day-first cultures **regardless of the
host's own locale**, so it reproduces on a US-locale CI runner rather than only on a
machine configured day-first. The pre-existing `DCDATE_Test` cases, which fail today on a
day-first host, pass with this change.
