### PR TITLE
Write UTF-8 to the console on non-Windows platforms

### DIFF
--- a/MBBSEmu.Tests/Session/LocalConsole/LocalConsoleSession_Tests.cs
+++ b/MBBSEmu.Tests/Session/LocalConsole/LocalConsoleSession_Tests.cs
@@ -1,0 +1,82 @@
+using MBBSEmu.Session.LocalConsole;
+using System;
+using System.Text;
+using Xunit;
+
+namespace MBBSEmu.Tests.Session.LocalConsole
+{
+    public class LocalConsoleSession_Tests
+    {
+        /// <summary>
+        ///     CP437 0xBA, the double vertical line that draws the border of most module ANSI
+        ///     art. LocalConsoleSession maps it to U+2551 before writing it to the console.
+        /// </summary>
+        private const ushort BOX_DRAWINGS_DOUBLE_VERTICAL = 0x2551;
+
+        /// <summary>
+        ///     Produces the bytes a terminal receives for one extended character, reproducing
+        ///     the conversion in LocalConsoleSession.UnicodeANSIOutput: the lookup table's
+        ///     UTF-16 code unit is turned into a string, which the console's output encoding
+        ///     then encodes. Console strips the encoding preamble itself, so encoding the
+        ///     string directly is what a single Console.Write emits.
+        /// </summary>
+        private static byte[] Encode(ushort unicodeCodePoint, Encoding encoding) =>
+            encoding.GetBytes(Encoding.Unicode.GetString(BitConverter.GetBytes(unicodeCodePoint)));
+
+        [Fact]
+        public void NonWindows_EncodesExtendedCharactersAsUTF8()
+        {
+            var encoding = LocalConsoleSession.GetConsoleOutputEncoding(isWindows: false);
+
+            //U+2551 is three bytes in UTF-8, which is what a Unix terminal expects
+            Assert.Equal(new byte[] { 0xE2, 0x95, 0x91 }, Encode(BOX_DRAWINGS_DOUBLE_VERTICAL, encoding));
+        }
+
+        [Fact]
+        public void NonWindows_LeavesASCIIUntouched()
+        {
+            var encoding = LocalConsoleSession.GetConsoleOutputEncoding(isWindows: false);
+
+            Assert.Equal(new byte[] { 0x41 }, Encode('A', encoding));
+        }
+
+        [Fact]
+        public void NonWindows_EmitsNoByteOrderMark()
+        {
+            var encoding = LocalConsoleSession.GetConsoleOutputEncoding(isWindows: false);
+
+            Assert.Empty(encoding.GetPreamble());
+        }
+
+        [Fact]
+        public void Windows_KeepsUTF16SoWriteConsoleWStillReceivesIt()
+        {
+            var encoding = LocalConsoleSession.GetConsoleOutputEncoding(isWindows: true);
+
+            Assert.Equal(Encoding.Unicode, encoding);
+        }
+
+        /// <summary>
+        ///     Pins the defect this fix exists for: under the previous unconditional UTF-16
+        ///     output, U+2551 reached a UTF-8 terminal as 0x51 0x25 and rendered as "Q%".
+        /// </summary>
+        [Fact]
+        public void UTF16Output_IsWhatMangledExtendedCharactersOnUnix()
+        {
+            var mangled = Encode(BOX_DRAWINGS_DOUBLE_VERTICAL, Encoding.Unicode);
+
+            Assert.Equal(new byte[] { 0x51, 0x25 }, mangled);
+            Assert.Equal("Q%", Encoding.ASCII.GetString(mangled));
+        }
+
+        /// <summary>
+        ///     ASCII survived the UTF-16 output only because its high byte is NUL, which
+        ///     terminals discard. This is why the defect looked cosmetic rather than total.
+        /// </summary>
+        [Fact]
+        public void UTF16Output_PaddedASCIIWithANullByte()
+        {
+            Assert.Equal(new byte[] { 0x41, 0x00 }, Encode('A', Encoding.Unicode));
+        }
+    }
+}

--- a/MBBSEmu/Session/LocalConsole/LocalConsoleSession.cs
+++ b/MBBSEmu/Session/LocalConsole/LocalConsoleSession.cs
@@ -68,7 +68,7 @@ namespace MBBSEmu.Session.LocalConsole
 
             Console.Clear();
 
-            Console.OutputEncoding = Encoding.Unicode;
+            Console.OutputEncoding = GetConsoleOutputEncoding(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
 
             //Detect if we're on Windows and enable VT100 on the current Terminal Window
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -86,6 +86,21 @@ namespace MBBSEmu.Session.LocalConsole
 
             _host?.AddSession(this);
         }
+
+        /// <summary>
+        ///     Returns the console output encoding appropriate for the host platform.
+        ///
+        ///     The Windows console renders UTF-16 correctly because .NET routes it through
+        ///     WriteConsoleW, but a Unix terminal reads the raw UTF-16LE bytes as UTF-8: the
+        ///     box-drawing character U+2551 emits 0x51 0x25 and prints as "Q%", which garbles
+        ///     every piece of ANSI art. ASCII appears to survive only because its high byte is
+        ///     NUL, which terminals discard.
+        ///
+        ///     The UTF-8 encoding is explicitly BOM-free. Console suppresses preambles on its
+        ///     own, but returning a BOM-free encoding keeps the result correct for any writer.
+        /// </summary>
+        public static Encoding GetConsoleOutputEncoding(bool isWindows) =>
+            isWindows ? Encoding.Unicode : new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
         private void InputThread()
         {


### PR DESCRIPTION
## Why

`-CONSOLE` mode is unusable for ANSI art on macOS and Linux. `LocalConsoleSession`
sets `Console.OutputEncoding` to `Encoding.Unicode` (UTF-16LE) unconditionally, so
every extended character reaches the terminal as two raw UTF-16 bytes. A UTF-8
terminal reads those as separate characters: the box-drawing character `║` (U+2551)
arrives as `0x51 0x25` and prints as `Q%`, which garbles the banner and all module
art. ASCII appears to survive only because its high byte is NUL, which terminals
discard.

The conversion table and `UnicodeANSIOutput` were already correct — they produce the
right `char`. Only the output encoding was wrong.

Fixes #667. (see there for initial screenshot)

## What changed

`GetConsoleOutputEncoding` now picks the encoding by platform: UTF-16 on Windows,
BOM-free UTF-8 everywhere else.

Windows keeps its current behavior deliberately. .NET routes UTF-16 console output
through `WriteConsoleW`, which renders the full BMP regardless of the console's code
page, so switching Windows to UTF-8 would trade a fixed bug for an unverified one.

The encoding choice is a separate method rather than an inline conditional because it
is the only part of this file a test can reach. The session constructor clears the
console and starts two threads, so it cannot be constructed in a unit test, and
routing `Console.Out` to a `StringWriter` would not help — a `StringWriter` holds
`char`s and never applies an encoding, which is the layer where this bug lives.

## Verification

Six tests in `MBBSEmu.Tests/Session/LocalConsole/LocalConsoleSession_Tests.cs` assert
the bytes a terminal receives, encoding through the same path as a single
`Console.Write`. Two of them pin the defect itself: that UTF-16 output turns U+2551
into `Q%`, and that it pads ASCII with a NUL byte.

Reverting `GetConsoleOutputEncoding` to the previous unconditional UTF-16 fails three
of the six. The other three — those two plus the Windows case — describe behavior the fix
preserves on purpose, so they pass either way.

Verified by hand that the fix produces the bytes a UTF-8 terminal expects:

```
Encoding.Unicode:  41 00 51 25 42 00   ->  "A Q%B "
Encoding.UTF8:     41 e2 95 91 42      ->  "A║B"
```

## Platform coverage

| Platform | `-CONSOLE` banner |
|---|---|
| macOS — Terminal and Ghostty | Correct |
| Linux aarch64 — `dotnet/sdk:10.0` container | Correct |
| Windows | Unchanged by this PR, and unverified |

Linux was checked with a negative control: reverting only `GetConsoleOutputEncoding` to
the previous unconditional UTF-16, in the same container and terminal, brings the mojibake
back. So the encoding choice is what changes the result there, not the environment. That
container had `LANG` and `LC_ALL` unset, which is the usual state for a stock image.

Windows keeps `Encoding.Unicode` and so behaves exactly as it does on master. I have no
Windows machine, so I cannot confirm the banner is correct there. Since nothing changes,
the risk is the bug persisting rather than a regression, but a `-CONSOLE` smoke test on
Windows would close the gap.

On forcing UTF-8 rather than letting .NET derive the encoding from the locale: measured,
.NET already selects UTF-8 for `LANG=en_US.UTF-8`, `C`, `POSIX`, and unset, so the two
agree everywhere a stock install lands. They diverge only for an explicitly non-UTF-8
locale such as `en_US.ISO8859-1`, where .NET emits `?` for U+2551 and this PR emits UTF-8
bytes. Neither renders the art, since ISO-8859-1 has no box-drawing characters, and master
was broken there too.

## Visual verification

MacOS + terminal + SF Mono Regular + UTF-8

<img width="988" height="553" alt="image" src="https://github.com/user-attachments/assets/71ce88bc-8c92-4f31-95d4-ce31fcf68314" />

MacOS + Ghostty (custom theme) + UTF-8

<img width="1095" height="674" alt="image" src="https://github.com/user-attachments/assets/879cc81a-3f6c-4d6b-846e-488c436b0059" />

Each screenshot runs `cat replay-before.bin` — the byte stream master emits — followed by `cat replay-after.ans`. Bytes that are not printable ASCII have no glyph, so each terminal substitutes its own replacement character.

The two terminals also draw the fixed output differently — Ghostty tiles the block elements flush into the wordmark while SF Mono leaves gaps between them — which is font metrics rather than encoding, since the bytes are identical.

