### PR TITLE
Fix NEG to set OF only for 0x80/0x8000

### DIFF
--- a/MBBSEmu.Tests/CPU/NEG_Tests.cs
+++ b/MBBSEmu.Tests/CPU/NEG_Tests.cs
@@ -8,13 +8,13 @@ namespace MBBSEmu.Tests.CPU
     {
         //Unit Tests using xUnit to perform testing of the NEG opcode in CPUCore
         [Theory]
-        [InlineData(0x00, 0x00, false, false)]
-        [InlineData(0x01, 0xFF, true, true)]
-        [InlineData(0x7F, 0x81, true, true)]
-        [InlineData(0x80, 0x80, true, true)]
-        [InlineData(0xFF, 0x01, false, true)]
-        [InlineData(0x81, 0x7F, false, true)]
-        public void NEG_8_Register_Test(byte input, byte expectedValue, bool expectedSF, bool expectedCF)
+        [InlineData(0x00, 0x00, false, false, false)]
+        [InlineData(0x01, 0xFF, true, true, false)]
+        [InlineData(0x7F, 0x81, true, true, false)]
+        [InlineData(0x80, 0x80, true, true, true)]
+        [InlineData(0xFF, 0x01, false, true, false)]
+        [InlineData(0x81, 0x7F, false, true, false)]
+        public void NEG_8_Register_Test(byte input, byte expectedValue, bool expectedSF, bool expectedCF, bool expectedOF)
         {
             Reset();
             mbbsEmuCpuRegisters.AL = input;
@@ -28,17 +28,19 @@ namespace MBBSEmu.Tests.CPU
             Assert.Equal(expectedValue, mbbsEmuCpuRegisters.AL);
             Assert.Equal(expectedSF, mbbsEmuCpuRegisters.SignFlag);
             Assert.Equal(expectedCF, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(expectedOF, mbbsEmuCpuRegisters.OverflowFlag);
         }
 
         //16bit Register Unit Tests for NEG
         [Theory]
-        [InlineData(0x0000, 0x0000, false, false)]
-        [InlineData(0x0001, 0xFFFF, true, true)]
-        [InlineData(0x7FFF, 0x8001, true, true)]
-        [InlineData(0x8000, 0x8000, true, true)]
-        [InlineData(0xFFFF, 0x0001, false, true)]
-        [InlineData(0x8001, 0x7FFF, false, true)]
-        public void NEG_16_Register_Test(ushort input, ushort expectedValue, bool expectedSF, bool expectedCF)
+        [InlineData(0x0000, 0x0000, false, false, false)]
+        [InlineData(0x0001, 0xFFFF, true, true, false)]
+        [InlineData(0x7FFF, 0x8001, true, true, false)]
+        [InlineData(0x8000, 0x8000, true, true, true)]
+        [InlineData(0xFFFF, 0x0001, false, true, false)]
+        [InlineData(0x8001, 0x7FFF, false, true, false)]
+        [InlineData(0xFF87, 0x0079, false, true, false)] //neg cx in Borland startup code (e.g. BBSFNDO.EXE)
+        public void NEG_16_Register_Test(ushort input, ushort expectedValue, bool expectedSF, bool expectedCF, bool expectedOF)
         {
             Reset();
             mbbsEmuCpuRegisters.AX = input;
@@ -52,6 +54,7 @@ namespace MBBSEmu.Tests.CPU
             Assert.Equal(expectedValue, mbbsEmuCpuRegisters.AX);
             Assert.Equal(expectedSF, mbbsEmuCpuRegisters.SignFlag);
             Assert.Equal(expectedCF, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(expectedOF, mbbsEmuCpuRegisters.OverflowFlag);
         }
 
     }

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -1573,7 +1573,9 @@ namespace MBBSEmu.CPU
             {
                 var result = (byte)-destination;
                 Registers.CarryFlag = destination != 0;
-                Flags_EvaluateOverflow(EnumArithmeticOperation.Subtraction, result, destination);
+                //NEG is 0 - destination, so the operand is the source of the subtraction;
+                //OF is set only for 0x80, the value whose negation doesn't fit
+                Flags_EvaluateOverflow(EnumArithmeticOperation.Subtraction, result, source: destination);
                 Flags_EvaluateSignZero(result);
                 return result;
             }
@@ -1587,7 +1589,9 @@ namespace MBBSEmu.CPU
             {
                 var result = (ushort)-destination;
                 Registers.CarryFlag = destination != 0;
-                Flags_EvaluateOverflow(EnumArithmeticOperation.Subtraction, result, destination);
+                //NEG is 0 - destination, so the operand is the source of the subtraction;
+                //OF is set only for 0x8000, the value whose negation doesn't fit
+                Flags_EvaluateOverflow(EnumArithmeticOperation.Subtraction, result, source: destination);
                 Flags_EvaluateSignZero(result);
                 return result;
             }


### PR DESCRIPTION
Fixes item 4 of #668.

`Op_Neg_8`/`Op_Neg_16` pass the operand to `Flags_EvaluateOverflow` as the minuend, with the subtrahend defaulted to 0. The negative−positive rule then sets OF for every negative operand whose negation comes out positive, where hardware sets OF after NEG only for 0x80/0x8000 — the values whose negation doesn't fit. This shows up in the wild: Borland startup code (BBSFNDO.EXE, a 1994 MajorBBS utility) runs `neg cx` with CX=0xFF87 and gets OF=1 where hardware gives OF=0.

**The change.** NEG is `0 − destination`, so the operand belongs on the *source* side of the subtraction: `Flags_EvaluateOverflow(Subtraction, result, source: destination)`. With the minuend 0, the evaluator's existing positive−negative==negative rule fires exactly for 0x80/0x8000. Value, CF, SF, and ZF are computed as before.

**Verification.** `NEG_Tests` now asserts OF on every row (previously value/SF/CF only), including 0x80/0x8000 with OF set and the BBSFNDO repro (0xFF87 → 0x0079, OF clear). Full suite passes: 2,583/2,583.