### PR TITLE
Fix ROR count handling for counts of 0 and above the operand width

### DIFF
--- a/MBBSEmu.Tests/CPU/ROR_Tests.cs
+++ b/MBBSEmu.Tests/CPU/ROR_Tests.cs
@@ -169,5 +169,85 @@ namespace MBBSEmu.Tests.CPU
 
             Assert.Equal(0x80 >> 7, mbbsEmuMemoryCore.GetByte(2, 0));
         }
+
+        [Theory]
+        [InlineData(0x81, 4, 0x18, false)]
+        [InlineData(0x03, 2, 0xC0, true)]
+        public void ROR_AL_MultiBit(byte alValue, byte count, byte alExpectedValue, bool carry)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AL = alValue;
+
+            var instructions = new Assembler(16);
+            instructions.ror(al, count);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(alExpectedValue, mbbsEmuCpuRegisters.AL);
+            Assert.Equal(carry, mbbsEmuCpuRegisters.CarryFlag);
+        }
+
+        [Theory]
+        [InlineData(0x81, 9, 0xC0, true)] // count masked to 5 bits, then mod 8: 9 ≡ 1
+        [InlineData(0x81, 8, 0x81, true)] // full width: identity, CF = MSB of result
+        [InlineData(0x80, 33, 0x40, false)] // 33 & 0x1F = 1
+        public void ROR_AL_CL(byte alValue, byte clValue, byte alExpectedValue, bool carry)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AL = alValue;
+            mbbsEmuCpuRegisters.CL = clValue;
+
+            var instructions = new Assembler(16);
+            instructions.ror(al, cl);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(alExpectedValue, mbbsEmuCpuRegisters.AL);
+            Assert.Equal(carry, mbbsEmuCpuRegisters.CarryFlag);
+        }
+
+        [Theory]
+        [InlineData(0x0002, 17, 0x0001, false)] // 17 ≡ 1 mod 16
+        [InlineData(0x0001, 17, 0x8000, true)]
+        [InlineData(0xAAAA, 16, 0xAAAA, true)] // full rotation is identity; CF = MSB of result
+        public void ROR_AX_CL(ushort axValue, byte clValue, ushort axExpectedValue, bool carry)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AX = axValue;
+            mbbsEmuCpuRegisters.CL = clValue;
+
+            var instructions = new Assembler(16);
+            instructions.ror(ax, cl);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(axExpectedValue, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(carry, mbbsEmuCpuRegisters.CarryFlag);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(32)] // masks to 0
+        public void ROR_AX_CL_MaskedZeroCount_LeavesValueAndFlags(byte clValue)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AX = 0x8001;
+            mbbsEmuCpuRegisters.CL = clValue;
+            mbbsEmuCpuRegisters.CarryFlag = true;
+            mbbsEmuCpuRegisters.OverflowFlag = true;
+
+            var instructions = new Assembler(16);
+            instructions.ror(ax, cl);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(0x8001, mbbsEmuCpuRegisters.AX);
+            Assert.True(mbbsEmuCpuRegisters.CarryFlag);
+            Assert.True(mbbsEmuCpuRegisters.OverflowFlag);
+        }
     }
 }

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -4339,11 +4339,20 @@ namespace MBBSEmu.CPU
             var destination = GetOperandValueUInt8(_currentInstruction.Op0Kind, EnumOperandType.Destination);
             var source = GetOperandValueUInt8(_currentInstruction.Op1Kind, EnumOperandType.Source);
 
+            //286+ masks the count to 5 bits; a masked count of 0 leaves the
+            //destination and all flags untouched
+            source &= 0x1F;
+            if (source == 0)
+                return destination;
+
             unchecked
             {
-                var result = (byte)((destination >> (sbyte)source) | (destination << (8 - (sbyte)source)));
+                //rotation is modulo the operand width; a multiple of the width
+                //(count 8, 16, 24) is the identity but still updates CF below
+                var rotate = source % 8;
+                var result = (byte)((destination >> rotate) | (destination << (8 - rotate)));
 
-                //CF Set if Most Significant Bit set to 1
+                //CF Set if Most Significant Bit set to 1 (the bit rotated out of the bottom)
                 Registers.CarryFlag = result.IsNegative();
 
                 //If Bits 7 & 6 are not the same, then we overflowed for 1 bit rotations
@@ -4364,11 +4373,20 @@ namespace MBBSEmu.CPU
             var destination = GetOperandValueUInt16(_currentInstruction.Op0Kind, EnumOperandType.Destination);
             var source = GetOperandValueUInt16(_currentInstruction.Op1Kind, EnumOperandType.Source);
 
+            //286+ masks the count to 5 bits; a masked count of 0 leaves the
+            //destination and all flags untouched
+            source &= 0x1F;
+            if (source == 0)
+                return destination;
+
             unchecked
             {
-                var result = (ushort)((destination >> (sbyte)source) | (destination << (16 - (sbyte)source)));
+                //rotation is modulo the operand width; a multiple of the width
+                //(count 16) is the identity but still updates CF below
+                var rotate = source % 16;
+                var result = (ushort)((destination >> rotate) | (destination << (16 - rotate)));
 
-                //CF Set if Most Significant Bit set to 1
+                //CF Set if Most Significant Bit set to 1 (the bit rotated out of the bottom)
                 Registers.CarryFlag = result.IsNegative();
 
                 //If Bits 15 & 14 are not the same, then we overflowed for 1 bit rotations


### PR DESCRIPTION
Fixes item 7 of #668 — the follow-up noted in #670.

`Op_Ror_8`/`Op_Ror_16` use the closed-form rotate with no count masking. For a count above the operand width, the wrap term's shift amount goes negative, C# masks the *shift* (not the count) to 5 bits, and the truncated result collapses to garbage: `ror al, 9` on 0x81 gives 0x00 where a 286+ masks the count to 5 bits, rotates modulo the width, and gives 0xC0. A masked count of 0 (CL=0 or CL=32) should leave the destination and all flags untouched, but the handler always writes CF. The `cl`-register encodings are the ones compilers emit, so out-of-range counts occur in practice.

**The change.** The same count handling as the ROL implementation from #670 (and the RCL/RCR masking from #663): `source &= 0x1F`, return unchanged on masked 0, rotate modulo the width. Flag conventions are unchanged — CF is the MSB of the result (the bit rotated out of the bottom), OF for 1-bit rotations as before.

**Verification.** `ROR_Tests` grows from 10 to 20 cases, mirroring `ROL_Tests`: multi-bit rotations, `cl` forms with wrapped and out-of-range counts (8, 9, 16, 17, 33), full-width identity rotations with CF assertions, and flag preservation at masked count 0. The existing cases are unchanged. All 1,057 tests in the CPU namespace pass locally; the change is confined to the two ROR handlers.