### PR TITLE
Implement printf %x and %X, and stop reading past the format string

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/sprintf_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/sprintf_Tests.cs
@@ -42,6 +42,13 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("%%%%% ", "%%% ", null)] //Escaped & Unescaped %
         [InlineData("%-8s", "gold crowns", "gold crowns")]
         [InlineData("%-8s", "gold    ", "gold")]
+        //Hex conversions (#683): accepted by PRINTF_SPECIFIERS but previously unimplemented
+        [InlineData("%x", "ff", (ushort)255)]
+        [InlineData("%X", "FF", (ushort)255)]
+        [InlineData("0x%x", "0x13", (ushort)19)]
+        [InlineData("%lx", "deadbeef", (uint)0xDEADBEEF)]
+        //A trailing unimplemented specifier used to read past the end of the format string
+        [InlineData("%o", "%o", (ushort)8)]
         public void sprintf_Test(string formatString, string expectedString, params object[] values)
         {
             Reset();

--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -636,6 +636,52 @@ namespace MBBSEmu.HostProcess.ExportedModules
                                 msFormattedValue.Write(Encoding.ASCII.GetBytes(value.ToString()));
                                 break;
                             }
+                        //Hex is always unsigned, so the value is never sign-extended the way i/d are
+                        case 'x':
+                        case 'X':
+                            {
+                                if (stringPrecision > 0)
+                                {
+                                    padCharacter = '0';
+                                    // can't left justify a digit with 0 since it changes the digit
+                                    stringFlags &= ~EnumPrintfFlags.LeftJustify;
+                                }
+
+                                ulong hexValue;
+                                if (isVsPrintf)
+                                {
+                                    if (variableLength == 4)
+                                    {
+                                        var longLow = Module.Memory.GetWord(vsPrintfBase);
+                                        vsPrintfBase.Offset += 2;
+                                        var longHigh = Module.Memory.GetWord(vsPrintfBase);
+                                        vsPrintfBase.Offset += 2;
+                                        hexValue = (uint)longHigh << 16 | (uint)longLow;
+                                    }
+                                    else
+                                    {
+                                        hexValue = Module.Memory.GetWord(vsPrintfBase);
+                                        vsPrintfBase.Offset += 2;
+                                    }
+                                }
+                                else
+                                {
+                                    if (variableLength == 4)
+                                    {
+                                        var longLow = GetParameter(currentParameter++);
+                                        var longHigh = GetParameter(currentParameter++);
+                                        hexValue = (uint)longHigh << 16 | (uint)longLow;
+                                    }
+                                    else
+                                    {
+                                        hexValue = GetParameter(currentParameter++);
+                                    }
+                                }
+
+                                msFormattedValue.Write(Encoding.ASCII.GetBytes(
+                                    hexValue.ToString(stringToParse[i] == 'X' ? "X" : "x")));
+                                break;
+                            }
                         case 'f':
                             {
                                 var floatValue = new byte[8];
@@ -659,7 +705,9 @@ namespace MBBSEmu.HostProcess.ExportedModules
                             }
                         default:
                             {
-                                _logger.Warn($"({Module.ModuleIdentifier}) Unhandled Printf Control Character: {(char)stringToParse[i + 1]}");
+                                //i is already at the specifier here, so reading i+1 walked off the
+                                //end whenever an unimplemented specifier ended the format string
+                                _logger.Warn($"({Module.ModuleIdentifier}) Unhandled Printf Control Character: {(char)stringToParse[i]}");
                                 msOutput.Write(stringToParse.Slice(controlStart, (i - controlStart) + 1));
                                 continue;
                             }


### PR DESCRIPTION
`PRINTF_SPECIFIERS` accepts `x` and `X`, but the conversion switch in `FormatPrintf` never implemented them, so both fell through to the `default` branch. Two problems follow from that.

Hex conversions produce no converted output — the argument is dropped and the specifier passes through as literal text.

The `default` branch also logs `stringToParse[i + 1]`, while `i` is already at the specifier; the code just above it says as much (`//Finally i should be at the specifier`). For a format string that ends in an unimplemented specifier, that reads one byte past the end and throws `IndexOutOfRangeException` — so the diagnostic meant to warn about an unhandled specifier crashes the module instead.

The new output playground option in MBBSEmu.Module calls `sprintf(dst, "%X", c)`, which is how this came up: on current master, entering that option crashes the module.

## What changed

`%x` and `%X` are implemented, mirroring the parameter fetch in the `i`/`d`/`u` case and covering the `l` long variants. Hex is unsigned, so the value is never sign-extended the way `%d` is.

The `default` branch now reads `stringToParse[i]`, the specifier it is reporting. The specifiers that remain unimplemented — `o`, `e`, `E`, `g`, `G`, `P`, and `N` — log a warning and pass through as literal text instead of throwing.

## Not included

`EnumPrintfFlags.LeftPadZero` is set while parsing the `0` flag but never read afterwards, so `%04x` pads with spaces rather than zeros. That predates this change and applies equally to `%04d`, so it is left for its own fix.

## Verification

- New `sprintf_Tests` cases cover `%x`, `%X`, `0x%x`, and `%lx`, plus a trailing `%o` that reproduces the out-of-bounds read.
- Full suite: 2675 passed, 0 failed, as of 2026-08-24.
