### PR TITLE
Fix SHLD's source fill and implement SHRD

### DIFF
--- a/MBBSEmu.Tests/CPU/SHLD_Tests.cs
+++ b/MBBSEmu.Tests/CPU/SHLD_Tests.cs
@@ -6,14 +6,20 @@ namespace MBBSEmu.Tests.CPU
 {
     public class SHLD_Tests : CpuTestBase
     {
+        //Counts 1, 16 and 32 are the three values where filling from the bottom of
+        //the source coincides with filling from the top, so rows using counts such
+        //as 4 and 8 with an asymmetric source are what actually pin the fill down
         [Theory]
         [InlineData(0xFFFFFFFF, 0x11111111, 16, 0xFFFF1111, true, false, true, false)]
-        [InlineData(0xFFFFFFFF, 0x11111111, 32, 0xFFFFFFFF, false, false, true, false)]
+        [InlineData(0xFFFFFFFF, 0x11111111, 32, 0xFFFFFFFF, false, false, false, false)]
         [InlineData(0x00001111, 0x11110000, 16, 0x11111111, false, false, false, false)]
         [InlineData(0xFFFF0000, 0xFFFF0000, 16, 0x0000FFFF, true, false, false, false)]
         [InlineData(0x7FFFFFFF, 0xFFFFFFFF, 1, 0xFFFFFFFF, false, true, true, false)]
         [InlineData(0x80000000, 0x00000000, 1, 0x00000000, true, true, false, true)]
         [InlineData(0x40000000, 0x00000000, 1, 0x80000000, false, true, true, false)] // Sign change with a source operand that is not itself negative
+        [InlineData(0x12345678, 0x9ABCDEF0, 8, 0x3456789A, false, false, false, false)] // Top 8 bits of the source fill, not the bottom 8
+        [InlineData(0x11111111, 0xF0000000, 4, 0x1111111F, true, false, false, false)]
+        [InlineData(0x80000000, 0x00FF0000, 8, 0x00000000, false, false, false, true)] // Source bits that are not in the top 8 must not appear
         public void SHLD_EAX_EBX_IMM8(uint eaxValue, uint ebxValue, byte count, uint expectedValue, bool carryFlag, bool overflowFlag, bool signFlag, bool zeroFlag)
         {
             Reset();
@@ -36,12 +42,15 @@ namespace MBBSEmu.Tests.CPU
 
         [Theory]
         [InlineData(0xFFFFFFFF, 0x11111111, 16, 0xFFFF1111, true, false, true, false)]
-        [InlineData(0xFFFFFFFF, 0x11111111, 32, 0xFFFFFFFF, false, false, true, false)]
+        [InlineData(0xFFFFFFFF, 0x11111111, 32, 0xFFFFFFFF, false, false, false, false)]
         [InlineData(0x00001111, 0x11110000, 16, 0x11111111, false, false, false, false)]
         [InlineData(0xFFFF0000, 0xFFFF0000, 16, 0x0000FFFF, true, false, false, false)]
         [InlineData(0x7FFFFFFF, 0xFFFFFFFF, 1, 0xFFFFFFFF, false, true, true, false)]
         [InlineData(0x80000000, 0x00000000, 1, 0x00000000, true, true, false, true)]
         [InlineData(0x40000000, 0x00000000, 1, 0x80000000, false, true, true, false)] // Sign change with a source operand that is not itself negative
+        [InlineData(0x12345678, 0x9ABCDEF0, 8, 0x3456789A, false, false, false, false)] // Top 8 bits of the source fill, not the bottom 8
+        [InlineData(0x11111111, 0xF0000000, 4, 0x1111111F, true, false, false, false)]
+        [InlineData(0x80000000, 0x00FF0000, 8, 0x00000000, false, false, false, true)] // Source bits that are not in the top 8 must not appear
         public void SHLD_EAX_EBX_CL(uint eaxValue, uint ebxValue, byte count, uint expectedValue, bool carryFlag, bool overflowFlag, bool signFlag, bool zeroFlag)
         {
             Reset();
@@ -61,6 +70,62 @@ namespace MBBSEmu.Tests.CPU
             Assert.Equal(overflowFlag, mbbsEmuCpuRegisters.OverflowFlag);
             Assert.Equal(signFlag, mbbsEmuCpuRegisters.SignFlag);
             Assert.Equal(zeroFlag, mbbsEmuCpuRegisters.ZeroFlag);
+        }
+
+        [Theory]
+        [InlineData(0x1234, 0xABCD, 4, 0x234A, true, false, false, false)]
+        [InlineData(0x8000, 0x00FF, 8, 0x0000, false, false, false, true)]
+        [InlineData(0x4000, 0x0000, 1, 0x8000, false, true, true, false)]
+        [InlineData(0xFFFF, 0x1111, 16, 0x1111, true, false, false, false)]
+        public void SHLD_AX_BX_IMM8(ushort axValue, ushort bxValue, byte count, ushort expectedValue, bool carryFlag, bool overflowFlag, bool signFlag, bool zeroFlag)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AX = axValue;
+            mbbsEmuCpuRegisters.BX = bxValue;
+
+            var instructions = new Assembler(16);
+            instructions.shld(ax, bx, count);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results
+            Assert.Equal(expectedValue, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(carryFlag, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(overflowFlag, mbbsEmuCpuRegisters.OverflowFlag);
+            Assert.Equal(signFlag, mbbsEmuCpuRegisters.SignFlag);
+            Assert.Equal(zeroFlag, mbbsEmuCpuRegisters.ZeroFlag);
+        }
+
+        /// <summary>
+        ///     A count that masks to zero must leave the destination and every flag
+        ///     alone, so the flags are set going in to tell "untouched" apart from
+        ///     "recomputed and happened to clear"
+        /// </summary>
+        [Theory]
+        [InlineData(0)]
+        [InlineData(32)]
+        public void SHLD_MaskedCountZero_ChangesNothing(byte count)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.EAX = 0x12345678;
+            mbbsEmuCpuRegisters.EBX = 0xFFFFFFFF;
+            mbbsEmuCpuRegisters.CarryFlag = true;
+            mbbsEmuCpuRegisters.OverflowFlag = true;
+            mbbsEmuCpuRegisters.SignFlag = true;
+            mbbsEmuCpuRegisters.ZeroFlag = true;
+
+            var instructions = new Assembler(16);
+            instructions.shld(eax, ebx, count);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(0x12345678u, mbbsEmuCpuRegisters.EAX);
+            Assert.True(mbbsEmuCpuRegisters.CarryFlag);
+            Assert.True(mbbsEmuCpuRegisters.OverflowFlag);
+            Assert.True(mbbsEmuCpuRegisters.SignFlag);
+            Assert.True(mbbsEmuCpuRegisters.ZeroFlag);
         }
     }
 }

--- a/MBBSEmu.Tests/CPU/SHRD_Tests.cs
+++ b/MBBSEmu.Tests/CPU/SHRD_Tests.cs
@@ -1,0 +1,120 @@
+﻿using Iced.Intel;
+using Xunit;
+using static Iced.Intel.AssemblerRegisters;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class SHRD_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(0x12345678, 0x9ABCDEF0, 8, 0xF0123456, false, false, true, false)] // Bottom 8 bits of the source fill from the top
+        [InlineData(0x11111111, 0x0000000F, 4, 0xF1111111, false, false, true, false)]
+        [InlineData(0x00000001, 0x00000000, 1, 0x00000000, true, false, false, true)]
+        [InlineData(0x00000000, 0x00000001, 1, 0x80000000, false, true, true, false)] // Source supplies the new sign bit, so OF is set
+        [InlineData(0xFFFFFFFF, 0x00000000, 16, 0x0000FFFF, true, false, false, false)]
+        [InlineData(0x12345678, 0xFFFFFFFF, 32, 0x12345678, false, false, false, false)] // Masked to a count of zero
+        public void SHRD_EAX_EBX_IMM8(uint eaxValue, uint ebxValue, byte count, uint expectedValue, bool carryFlag, bool overflowFlag, bool signFlag, bool zeroFlag)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.EAX = eaxValue;
+            mbbsEmuCpuRegisters.EBX = ebxValue;
+
+            var instructions = new Assembler(16);
+            instructions.shrd(eax, ebx, count);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results
+            Assert.Equal(expectedValue, mbbsEmuCpuRegisters.EAX);
+            Assert.Equal(carryFlag, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(overflowFlag, mbbsEmuCpuRegisters.OverflowFlag);
+            Assert.Equal(signFlag, mbbsEmuCpuRegisters.SignFlag);
+            Assert.Equal(zeroFlag, mbbsEmuCpuRegisters.ZeroFlag);
+        }
+
+        [Theory]
+        [InlineData(0x12345678, 0x9ABCDEF0, 8, 0xF0123456, false, false, true, false)]
+        [InlineData(0x11111111, 0x0000000F, 4, 0xF1111111, false, false, true, false)]
+        [InlineData(0x00000001, 0x00000000, 1, 0x00000000, true, false, false, true)]
+        [InlineData(0x00000000, 0x00000001, 1, 0x80000000, false, true, true, false)]
+        [InlineData(0xFFFFFFFF, 0x00000000, 16, 0x0000FFFF, true, false, false, false)]
+        [InlineData(0x12345678, 0xFFFFFFFF, 32, 0x12345678, false, false, false, false)]
+        public void SHRD_EAX_EBX_CL(uint eaxValue, uint ebxValue, byte count, uint expectedValue, bool carryFlag, bool overflowFlag, bool signFlag, bool zeroFlag)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.EAX = eaxValue;
+            mbbsEmuCpuRegisters.EBX = ebxValue;
+            mbbsEmuCpuRegisters.CL = count;
+
+            var instructions = new Assembler(16);
+            instructions.shrd(eax, ebx, cl);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results
+            Assert.Equal(expectedValue, mbbsEmuCpuRegisters.EAX);
+            Assert.Equal(carryFlag, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(overflowFlag, mbbsEmuCpuRegisters.OverflowFlag);
+            Assert.Equal(signFlag, mbbsEmuCpuRegisters.SignFlag);
+            Assert.Equal(zeroFlag, mbbsEmuCpuRegisters.ZeroFlag);
+        }
+
+        [Theory]
+        [InlineData(0x1234, 0xABCD, 4, 0xD123, false, false, true, false)]
+        [InlineData(0x00FF, 0x0000, 8, 0x0000, true, false, false, true)]
+        [InlineData(0x0000, 0x0001, 1, 0x8000, false, true, true, false)] // Source supplies the new sign bit, so OF is set
+        [InlineData(0xFFFF, 0x0000, 8, 0x00FF, true, false, false, false)]
+        public void SHRD_AX_BX_IMM8(ushort axValue, ushort bxValue, byte count, ushort expectedValue, bool carryFlag, bool overflowFlag, bool signFlag, bool zeroFlag)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AX = axValue;
+            mbbsEmuCpuRegisters.BX = bxValue;
+
+            var instructions = new Assembler(16);
+            instructions.shrd(ax, bx, count);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            //Verify Results
+            Assert.Equal(expectedValue, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(carryFlag, mbbsEmuCpuRegisters.CarryFlag);
+            Assert.Equal(overflowFlag, mbbsEmuCpuRegisters.OverflowFlag);
+            Assert.Equal(signFlag, mbbsEmuCpuRegisters.SignFlag);
+            Assert.Equal(zeroFlag, mbbsEmuCpuRegisters.ZeroFlag);
+        }
+
+        /// <summary>
+        ///     A count that masks to zero must leave the destination and every flag
+        ///     alone, so the flags are set going in to tell "untouched" apart from
+        ///     "recomputed and happened to clear"
+        /// </summary>
+        [Theory]
+        [InlineData(0)]
+        [InlineData(32)]
+        public void SHRD_MaskedCountZero_ChangesNothing(byte count)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.EAX = 0x12345678;
+            mbbsEmuCpuRegisters.EBX = 0xFFFFFFFF;
+            mbbsEmuCpuRegisters.CarryFlag = true;
+            mbbsEmuCpuRegisters.OverflowFlag = true;
+            mbbsEmuCpuRegisters.SignFlag = true;
+            mbbsEmuCpuRegisters.ZeroFlag = true;
+
+            var instructions = new Assembler(16);
+            instructions.shrd(eax, ebx, count);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(0x12345678u, mbbsEmuCpuRegisters.EAX);
+            Assert.True(mbbsEmuCpuRegisters.CarryFlag);
+            Assert.True(mbbsEmuCpuRegisters.OverflowFlag);
+            Assert.True(mbbsEmuCpuRegisters.SignFlag);
+            Assert.True(mbbsEmuCpuRegisters.ZeroFlag);
+        }
+    }
+}

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -4775,37 +4775,41 @@ namespace MBBSEmu.CPU
         [MethodImpl(OpcodeCompilerOptimizations)]
         private void Op_Shld()
         {
-            uint result;
-            switch (_currentOperationSize)
+            var result = _currentOperationSize switch
             {
-                case 4:
-                    result = Op_Shld_32();
-                    break;
-                default:
-                    throw new Exception("Unsupported Operation Size");
-            }
+                2 => Op_Shld_16(),
+                4 => Op_Shld_32(),
+                _ => throw new Exception("Unsupported Operation Size")
+            };
 
             WriteToDestination(result);
         }
 
+        /// <summary>
+        ///     16-bit Extended Shift Left
+        /// </summary>
         [MethodImpl(OpcodeSubroutineCompilerOptimizations)]
-        private uint Op_Shld_32()
+        private ushort Op_Shld_16()
         {
-            var destination = GetOperandValueUInt32(_currentInstruction.Op0Kind, EnumOperandType.Destination);
-            var source = GetOperandValueUInt32(_currentInstruction.Op1Kind, EnumOperandType.Source);
+            var destination = GetOperandValueUInt16(_currentInstruction.Op0Kind, EnumOperandType.Destination);
+            var source = GetOperandValueUInt16(_currentInstruction.Op1Kind, EnumOperandType.Source);
             var count = GetOperandValueUInt8(_currentInstruction.Op2Kind, EnumOperandType.Count);
 
-            //Make sure Count isn't > 32 bits
+            //286+ masks the count to 5 bits; a masked count of 0 leaves the
+            //destination and all flags untouched
             count &= 0x1F;
+            if (count == 0)
+                return destination;
 
-            var result = destination << count;
-            result |= (source >> count);
+            //Shifting the pair as one 32-bit value keeps the fill and the carry bit
+            //in range for counts above the 16-bit operand width, where the result is
+            //undefined on hardware but must still not throw
+            var pair = ((uint)destination << 16) | source;
 
-            if (count > 0)
-            {
-                //CF == the last bit shifted out of the destination
-                Registers.CarryFlag = destination.IsBitSet((sizeof(uint) * 8) - count);
-            }
+            //CF == the last bit shifted out of the destination
+            Registers.CarryFlag = (pair & (1u << (32 - count))) != 0;
+
+            var result = (ushort)((pair << count) >> 16);
 
             //Only evaluate Overflow on Shift of 1 Bit, otherwise it's clear
             if (count == 1)
@@ -4816,8 +4820,43 @@ namespace MBBSEmu.CPU
             Flags_EvaluateSignZero(result);
 
             return result;
-
         }
+
+        /// <summary>
+        ///     32-bit Extended Shift Left
+        /// </summary>
+        [MethodImpl(OpcodeSubroutineCompilerOptimizations)]
+        private uint Op_Shld_32()
+        {
+            var destination = GetOperandValueUInt32(_currentInstruction.Op0Kind, EnumOperandType.Destination);
+            var source = GetOperandValueUInt32(_currentInstruction.Op1Kind, EnumOperandType.Source);
+            var count = GetOperandValueUInt8(_currentInstruction.Op2Kind, EnumOperandType.Count);
+
+            //286+ masks the count to 5 bits; a masked count of 0 leaves the
+            //destination and all flags untouched
+            count &= 0x1F;
+            if (count == 0)
+                return destination;
+
+            //The vacated low bits take the TOP count bits of the source, not its
+            //bottom ones -- source >> count only happens to agree at counts 1, 16
+            //and 32, which is every count the original tests covered
+            var result = (destination << count) | (source >> ((sizeof(uint) * 8) - count));
+
+            //CF == the last bit shifted out of the destination
+            Registers.CarryFlag = destination.IsBitSet((sizeof(uint) * 8) - count);
+
+            //Only evaluate Overflow on Shift of 1 Bit, otherwise it's clear
+            if (count == 1)
+                Flags_EvaluateOverflow(EnumArithmeticOperation.ShiftLeft, result, destination, count);
+            else
+                Registers.OverflowFlag = false;
+
+            Flags_EvaluateSignZero(result);
+
+            return result;
+        }
+
 
         /// <summary>
         ///     Evaluates the given 8-bit operation and parameters to evaluate the status of the Carry Flag

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -782,6 +782,9 @@ namespace MBBSEmu.CPU
                 case Mnemonic.Shld:
                     Op_Shld();
                     break;
+                case Mnemonic.Shrd:
+                    Op_Shrd();
+                    break;
                 case Mnemonic.Mul:
                     Op_Mul();
                     break;
@@ -4857,6 +4860,95 @@ namespace MBBSEmu.CPU
             return result;
         }
 
+        /// <summary>
+        ///     Extended Shift Right
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Shrd()
+        {
+            var result = _currentOperationSize switch
+            {
+                2 => Op_Shrd_16(),
+                4 => Op_Shrd_32(),
+                _ => throw new Exception("Unsupported Operation Size")
+            };
+
+            WriteToDestination(result);
+        }
+
+        /// <summary>
+        ///     16-bit Extended Shift Right
+        /// </summary>
+        [MethodImpl(OpcodeSubroutineCompilerOptimizations)]
+        private ushort Op_Shrd_16()
+        {
+            var destination = GetOperandValueUInt16(_currentInstruction.Op0Kind, EnumOperandType.Destination);
+            var source = GetOperandValueUInt16(_currentInstruction.Op1Kind, EnumOperandType.Source);
+            var count = GetOperandValueUInt8(_currentInstruction.Op2Kind, EnumOperandType.Count);
+
+            //286+ masks the count to 5 bits; a masked count of 0 leaves the
+            //destination and all flags untouched
+            count &= 0x1F;
+            if (count == 0)
+                return destination;
+
+            //Source feeds in from the top, so it occupies the high half of the pair
+            var pair = ((uint)source << 16) | destination;
+
+            //CF == the last bit shifted out of the destination
+            Registers.CarryFlag = (pair & (1u << (count - 1))) != 0;
+
+            var result = (ushort)(pair >> count);
+
+            //Only evaluate Overflow on Shift of 1 Bit, otherwise it's clear.
+            //SHRD shifts the source's bits into the top of the destination, so the
+            //SHR convention (OF == the destination's old sign) does not hold here --
+            //OF is set when the sign bit actually changed
+            if (count == 1)
+                Registers.OverflowFlag = result.IsNegative() != destination.IsNegative();
+            else
+                Registers.OverflowFlag = false;
+
+            Flags_EvaluateSignZero(result);
+
+            return result;
+        }
+
+        /// <summary>
+        ///     32-bit Extended Shift Right
+        /// </summary>
+        [MethodImpl(OpcodeSubroutineCompilerOptimizations)]
+        private uint Op_Shrd_32()
+        {
+            var destination = GetOperandValueUInt32(_currentInstruction.Op0Kind, EnumOperandType.Destination);
+            var source = GetOperandValueUInt32(_currentInstruction.Op1Kind, EnumOperandType.Source);
+            var count = GetOperandValueUInt8(_currentInstruction.Op2Kind, EnumOperandType.Count);
+
+            //286+ masks the count to 5 bits; a masked count of 0 leaves the
+            //destination and all flags untouched
+            count &= 0x1F;
+            if (count == 0)
+                return destination;
+
+            //The vacated high bits take the BOTTOM count bits of the source
+            var result = (destination >> count) | (source << ((sizeof(uint) * 8) - count));
+
+            //CF == the last bit shifted out of the destination
+            Registers.CarryFlag = destination.IsBitSet(count - 1);
+
+            //Only evaluate Overflow on Shift of 1 Bit, otherwise it's clear.
+            //SHRD shifts the source's bits into the top of the destination, so the
+            //SHR convention (OF == the destination's old sign) does not hold here --
+            //OF is set when the sign bit actually changed
+            if (count == 1)
+                Registers.OverflowFlag = result.IsNegative() != destination.IsNegative();
+            else
+                Registers.OverflowFlag = false;
+
+            Flags_EvaluateSignZero(result);
+
+            return result;
+        }
 
         /// <summary>
         ///     Evaluates the given 8-bit operation and parameters to evaluate the status of the Carry Flag


### PR DESCRIPTION
Fixes items 8 and 9 of #668.

SHLD and SHRD are the pair compilers emit for multi-word shifts in 16-bit code, so the cost of these is split: a module reaching SHLD gets silently wrong arithmetic, and one reaching SHRD stops with `Unsupported OpCode`.

**SHLD fills from the wrong end.** `Op_Shld_32` ORs in `source >> count`. SHLD takes the *top* `count` bits of the source, which is `source >> (32 - count)`: `shld eax, ebx, 8` with EBX=0x9ABCDEF0 contributes 0x009ABCDE where hardware contributes 0x9A. `SHLD_Tests` never caught this because every row uses a count of 1, 16, or 32, and those are exactly the counts where the two expressions coincide — 1 and 16 by the symmetry of the all-ones and repeated-nibble sources in the table, 32 via the count mask.

**A masked count of zero corrupts the destination.** With `count & 0x1F == 0` both shifts are by zero, so the result is `destination | source`, and the flags are then recomputed from that value. A 286+ masks the count to 5 bits, and a masked count of zero changes nothing.

**There is no 16-bit SHLD.** `Op_Shld` switches on operation size 4 only and throws `Unsupported Operation Size` otherwise. Item 8 describes the 16-bit path as having "the same shape" as the 32-bit one; that wording is stale, since the path does not exist.

**SHRD is not implemented.** `Tick()` has no `case Mnemonic.Shrd`, so any SHRD throws `Unsupported OpCode: Shrd` — the same gap ROL had before #670.

**The change.** `Op_Shld_32` now fills from the top of the source and returns early on a masked count of zero. New `Op_Shld_16`, and new `Op_Shrd` / `Op_Shrd_16` / `Op_Shrd_32` with its dispatch case. The 16-bit handlers shift the operand pair as one 32-bit value so that the fill and the carry bit stay in range for counts above the operand width, where the result is undefined on hardware but must still not throw.

Flag conventions follow the neighbouring shifts and are otherwise unchanged: the count is masked to 5 bits, a masked zero leaves the destination and every flag alone, OF is evaluated only at a count of 1, and SF/ZF for every nonzero count. SHRD's overflow needs its own treatment rather than the SHR convention. SHR always vacates the sign bit, so its OF is just the destination's old sign; SHRD shifts a source bit into that position, so OF is set when the sign changed. `shrd eax, ebx, 1` with EAX=0 and EBX=1 produces 0x80000000, which the SHR convention would report as no overflow.

**Verification.** `SHLD_Tests` grows from 14 to 26 cases and gains a 16-bit table; the new rows use counts of 4 and 8 with asymmetric operands, where filling from the top and from the bottom diverge. A new `SHRD_Tests` has 18 cases across the 32-bit imm8, 32-bit `cl`, and 16-bit forms, covering the fill, both carry ends, the sign-change overflow, and the count-zero no-op. Both suites set CF, OF, SF, and ZF before a masked-zero count and assert all four survive, which tells "untouched" apart from "recomputed and happened to clear". Every new row fails against the current implementation.

One existing expectation changes: the count-32 row in both SHLD tables asserted SF=true, which was the sign of the wrongly-recomputed result. A true no-op leaves SF as it was. The other 12 existing rows are unchanged and still pass.

All 1,098 tests in the CPU namespace pass locally; the change is confined to the SHLD and SHRD handlers and their dispatch cases.
