### PR TITLE
Compare fnd1st timestamps against the file, not the wall clock

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/fnd1st_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/fnd1st_Tests.cs
@@ -14,11 +14,15 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         private const int FND1ST_ORDINAL = 694;
         private const int FNDNXT_ORDINAL = 695;
 
-        private const long FIVE_SECOND_TICKS = 5 * 1_000 * 10_000;
+        //DOS directory entries store the time to a two-second boundary, so a
+        //decoded timestamp can legitimately sit either side of the real one
+        private static readonly TimeSpan DOS_TIMESTAMP_GRANULARITY = TimeSpan.FromSeconds(2);
 
-        private readonly long ticksNow = DateTime.Now.Ticks;
+        //Timestamp each file as it is written, so the assertions compare what fnd1st
+        //decoded against the file itself rather than against the clock
+        private readonly Dictionary<string, DateTime> _createdFiles = new();
 
-        public fnd1st_Tests() : base(Path.Join(Path.GetTempPath(), "fnd1st"))
+        public fnd1st_Tests() : base(Path.Join(Path.GetTempPath(), $"fnd1st{Guid.NewGuid():N}"))
         {
             Directory.CreateDirectory(mbbsModule.ModulePath);
         }
@@ -121,7 +125,10 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             var fbs = new FndblkStruct(mbbsEmuMemoryCore.GetArray(fndblkPointer, FndblkStruct.StructSize));
             Assert.Equal(9, fbs.Size);
             Assert.Equal(0, (byte)fbs.Attributes & (byte)~FndblkStruct.AttributeFlags.Archive);
-            Assert.True(Math.Abs(ticksNow - fbs.DateTime.Ticks) <= FIVE_SECOND_TICKS);
+            Assert.True(_createdFiles.TryGetValue(fbs.Name, out var writtenAt),
+                $"fnd1st returned \"{fbs.Name}\", which this test never created");
+            Assert.True((fbs.DateTime - writtenAt).Duration() <= DOS_TIMESTAMP_GRANULARITY,
+                $"fnd1st reported {fbs.DateTime:O} for \"{fbs.Name}\", which was written at {writtenAt:O}");
 
             return fbs.Name;
         }
@@ -169,6 +176,8 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             {
                 writer.Write("Testing\r\n");
             }
+
+            _createdFiles[Path.GetFileName(path)] = File.GetLastWriteTime(path);
         }
     }
 }


### PR DESCRIPTION
Fixes #678.

`fnd1st_Tests` fails intermittently in full-suite runs and passes every time in isolation. The cost is not the red run itself but what it looks like: a single named test in a class unrelated to whatever branch is under review, which reads like a real regression.

**Root cause.** `GetFileFromFndblk` asserted that the timestamp `fnd1st` decoded was within five seconds of `ticksNow`:

```csharp
private readonly long ticksNow = DateTime.Now.Ticks;
...
Assert.True(Math.Abs(ticksNow - fbs.DateTime.Ticks) <= FIVE_SECOND_TICKS);
```

`ticksNow` is a field initializer, and C# runs those before the base constructor. `ExportedModuleTestBase`'s constructor is not cheap under load: instrumenting it measured 4,353 ms during a full-suite run, against 73-180 ms in isolation. What remains of the five seconds then has to absorb DOS timestamp truncation, which is a further two seconds and can land either side of the real time — on an idle machine `fbs.DateTime` arrived 1.5-1.9 s *before* `ticksNow`. An instrumented run that passed still spent 3,761 ms of the 5,000 ms allowance. The margin was the bug.

This also corrects the diagnosis on the issue. The shared `$TMPDIR/fnd1st` directory is a genuine hazard, but it is not this failure: a directory race would fail at `Assert.Equal(1, mbbsEmuCpuRegisters.AX)` with the file missing, whereas the recorded stack fails inside `GetFileFromFndblk`, which only runs once the file has been found.

**The change.** The assertion now compares against the file's own `LastWriteTime`, recorded as each file is written, with a two-second tolerance for DOS granularity. That is what the assertion was for — checking that `fnd1st` decodes a directory entry correctly — and it does not depend on how long construction took. Both assertions carry a message naming the file and both timestamps, so a future failure explains itself instead of printing `Expected: True / Actual: False`.

The class also gets a per-instance temp directory, as suggested on the issue. That closes the shared-directory hazard, though on its own it would not have fixed the flake.

**Verification.** Sleeping ten seconds before creating the files reproduces the failure deterministically: with the same delay and the same test, the old assertion fails and the new one passes. The full suite is green at 2,624 tests, including a 25-minute contended run of the kind that produces the failure.
