### PR TITLE
Fix/634 fpu math opcodes

### DIFF
--- a/MBBSEmu.Tests/CPU/F2XM1_Tests.cs
+++ b/MBBSEmu.Tests/CPU/F2XM1_Tests.cs
@@ -1,0 +1,30 @@
+using Iced.Intel;
+using System;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class F2XM1_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(1d)]
+        [InlineData(-1d)]
+        [InlineData(0.5d)]
+        [InlineData(0d)]
+        public void F2XM1_Test(double ST0Value)
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(0);
+            mbbsEmuCpuCore.FpuStack[0] = ST0Value;
+
+            var instructions = new Assembler(16);
+            instructions.f2xm1();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(Math.Pow(2, ST0Value) - 1, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FABS_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FABS_Tests.cs
@@ -1,0 +1,30 @@
+using Iced.Intel;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FABS_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(-5d, 5d)]
+        [InlineData(5d, 5d)]
+        [InlineData(0d, 0d)]
+        [InlineData(double.NegativeInfinity, double.PositiveInfinity)]
+        [InlineData(double.NaN, double.NaN)]
+        public void FABS_Test(double ST0Value, double expectedValue)
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(0);
+            mbbsEmuCpuCore.FpuStack[0] = ST0Value;
+
+            var instructions = new Assembler(16);
+            instructions.fabs();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(expectedValue, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FDECSTP_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FDECSTP_Tests.cs
@@ -1,0 +1,29 @@
+using Iced.Intel;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FDECSTP_Tests : CpuTestBase
+    {
+        [Fact]
+        public void FDECSTP_Test()
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(1);
+            mbbsEmuCpuCore.FpuStack[1] = 111d; //ST0
+            mbbsEmuCpuCore.FpuStack[0] = 222d; //ST1
+            mbbsEmuCpuCore.FpuStack[2] = 333d;
+
+            var instructions = new Assembler(16);
+            instructions.fdecstp();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            //a new ST(0) slot is created, old ST(0) is now ST(1)
+            Assert.Equal(333d, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+            Assert.Equal(111d, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackPointer(Register.ST1)]);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FINCSTP_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FINCSTP_Tests.cs
@@ -1,0 +1,27 @@
+using Iced.Intel;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FINCSTP_Tests : CpuTestBase
+    {
+        [Fact]
+        public void FINCSTP_Test()
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(1);
+            mbbsEmuCpuCore.FpuStack[1] = 111d; //ST0
+            mbbsEmuCpuCore.FpuStack[0] = 222d; //ST1
+
+            var instructions = new Assembler(16);
+            instructions.fincstp();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            //old ST(1) is now ST(0)
+            Assert.Equal(222d, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FLDL2E_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FLDL2E_Tests.cs
@@ -1,0 +1,22 @@
+using Iced.Intel;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FLDL2E_Tests : CpuTestBase
+    {
+        [Fact]
+        public void FLDL2E_Test()
+        {
+            Reset();
+
+            var instructions = new Assembler(16);
+            instructions.fldl2e();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(1.4426950408889634d, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FLDL2T_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FLDL2T_Tests.cs
@@ -1,0 +1,22 @@
+using Iced.Intel;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FLDL2T_Tests : CpuTestBase
+    {
+        [Fact]
+        public void FLDL2T_Test()
+        {
+            Reset();
+
+            var instructions = new Assembler(16);
+            instructions.fldl2t();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(3.3219280948873623d, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FLDLG2_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FLDLG2_Tests.cs
@@ -1,0 +1,22 @@
+using Iced.Intel;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FLDLG2_Tests : CpuTestBase
+    {
+        [Fact]
+        public void FLDLG2_Test()
+        {
+            Reset();
+
+            var instructions = new Assembler(16);
+            instructions.fldlg2();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(0.3010299956639812d, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FLDLN2_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FLDLN2_Tests.cs
@@ -1,0 +1,22 @@
+using Iced.Intel;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FLDLN2_Tests : CpuTestBase
+    {
+        [Fact]
+        public void FLDLN2_Test()
+        {
+            Reset();
+
+            var instructions = new Assembler(16);
+            instructions.fldln2();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(0.6931471805599453d, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FPREM_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FPREM_Tests.cs
@@ -1,0 +1,29 @@
+using Iced.Intel;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FPREM_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(5.3d, 2d)]
+        [InlineData(-5.3d, 2d)]
+        [InlineData(10d, 3d)]
+        public void FPREM_Test(double ST0Value, double ST1Value)
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(1);
+            mbbsEmuCpuCore.FpuStack[1] = ST0Value; //ST0
+            mbbsEmuCpuCore.FpuStack[0] = ST1Value; //ST1
+
+            var instructions = new Assembler(16);
+            instructions.fprem();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(ST0Value % ST1Value, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FPTAN_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FPTAN_Tests.cs
@@ -1,0 +1,31 @@
+using Iced.Intel;
+using System;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FPTAN_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(1d)]
+        [InlineData(-1d)]
+        [InlineData(0d)]
+        public void FPTAN_Test(double ST0Value)
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(0);
+            mbbsEmuCpuCore.FpuStack[0] = ST0Value;
+
+            var instructions = new Assembler(16);
+            instructions.fptan();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            //ST(0) becomes 1.0, ST(1) becomes the tangent
+            Assert.Equal(1d, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+            Assert.Equal(Math.Tan(ST0Value), mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackPointer(Register.ST1)]);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FSINCOS_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FSINCOS_Tests.cs
@@ -1,0 +1,31 @@
+using Iced.Intel;
+using System;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FSINCOS_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(1d)]
+        [InlineData(-1d)]
+        [InlineData(0d)]
+        public void FSINCOS_Test(double ST0Value)
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(0);
+            mbbsEmuCpuCore.FpuStack[0] = ST0Value;
+
+            var instructions = new Assembler(16);
+            instructions.fsincos();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            //ST(0) becomes cosine, ST(1) becomes sine
+            Assert.Equal(Math.Cos(ST0Value), mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+            Assert.Equal(Math.Sin(ST0Value), mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackPointer(Register.ST1)]);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FXTRACT_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FXTRACT_Tests.cs
@@ -1,0 +1,31 @@
+using Iced.Intel;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FXTRACT_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(8d, 3d, 1d)]
+        [InlineData(1.5d, 0d, 1.5d)]
+        [InlineData(0.5d, -1d, 1d)]
+        [InlineData(1d, 0d, 1d)]
+        public void FXTRACT_Test(double ST0Value, double expectedExponent, double expectedSignificand)
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(0);
+            mbbsEmuCpuCore.FpuStack[0] = ST0Value;
+
+            var instructions = new Assembler(16);
+            instructions.fxtract();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            //ST(0) becomes the significand, ST(1) becomes the exponent
+            Assert.Equal(expectedSignificand, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+            Assert.Equal(expectedExponent, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackPointer(Register.ST1)]);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FYL2XP1_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FYL2XP1_Tests.cs
@@ -1,4 +1,6 @@
 using Iced.Intel;
+using MBBSEmu.CPU;
+using MBBSEmu.Extensions;
 using System;
 using Xunit;
 
@@ -10,6 +12,7 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(0.25d, 1d)]
         [InlineData(-0.5d, 3d)]
         [InlineData(0d, 1d)]
+        [InlineData(-1d, 5d)] // (ST0 + 1.0) == 0, ST1 nonzero -> signed Infinity, still valid
         public void FYL2XP1_Test(double ST0Value, double ST1Value)
         {
             Reset();
@@ -25,6 +28,29 @@ namespace MBBSEmu.Tests.CPU
             mbbsEmuCpuCore.Tick();
 
             Assert.Equal(ST1Value * Math.Log2(ST0Value + 1.0), mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+
+        [Theory]
+        [InlineData(-4d, 5d)] // (ST0 + 1.0) negative is an invalid operand
+        [InlineData(double.NaN, 5d)]
+        [InlineData(4d, double.NaN)]
+        [InlineData(-1d, 0d)] // (ST0 + 1.0) == 0, ST1 == 0 -> indeterminate
+        public void FYL2XP1_InvalidOperand_ReturnsNaNAndSetsInvalidOperationFlag(double ST0Value, double ST1Value)
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(1);
+            mbbsEmuCpuCore.FpuStack[1] = ST0Value; //ST0
+            mbbsEmuCpuCore.FpuStack[0] = ST1Value; //ST1
+
+            var instructions = new Assembler(16);
+            instructions.fyl2xp1();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(double.NaN, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+            Assert.True(mbbsEmuCpuRegisters.Fpu.ControlWord.IsFlagSet((ushort)EnumFpuControlWordFlags.InvalidOperation));
         }
     }
 }

--- a/MBBSEmu.Tests/CPU/FYL2XP1_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FYL2XP1_Tests.cs
@@ -1,0 +1,30 @@
+using Iced.Intel;
+using System;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FYL2XP1_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(0.25d, 1d)]
+        [InlineData(-0.5d, 3d)]
+        [InlineData(0d, 1d)]
+        public void FYL2XP1_Test(double ST0Value, double ST1Value)
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(1);
+            mbbsEmuCpuCore.FpuStack[1] = ST0Value; //ST0
+            mbbsEmuCpuCore.FpuStack[0] = ST1Value; //ST1
+
+            var instructions = new Assembler(16);
+            instructions.fyl2xp1();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(ST1Value * Math.Log2(ST0Value + 1.0), mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FYL2X_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FYL2X_Tests.cs
@@ -1,0 +1,30 @@
+using Iced.Intel;
+using System;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FYL2X_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(8d, 1d)]
+        [InlineData(2d, 3d)]
+        [InlineData(100d, 1d)]
+        public void FYL2X_Test(double ST0Value, double ST1Value)
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(1);
+            mbbsEmuCpuCore.FpuStack[1] = ST0Value; //ST0
+            mbbsEmuCpuCore.FpuStack[0] = ST1Value; //ST1
+
+            var instructions = new Assembler(16);
+            instructions.fyl2x();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(ST1Value * Math.Log2(ST0Value), mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FYL2X_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FYL2X_Tests.cs
@@ -1,4 +1,6 @@
 using Iced.Intel;
+using MBBSEmu.CPU;
+using MBBSEmu.Extensions;
 using System;
 using Xunit;
 
@@ -10,6 +12,10 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(8d, 1d)]
         [InlineData(2d, 3d)]
         [InlineData(100d, 1d)]
+        [InlineData(0d, 5d)]
+        [InlineData(0d, -5d)]
+        [InlineData(double.PositiveInfinity, 5d)]
+        [InlineData(double.PositiveInfinity, -5d)]
         public void FYL2X_Test(double ST0Value, double ST1Value)
         {
             Reset();
@@ -25,6 +31,30 @@ namespace MBBSEmu.Tests.CPU
             mbbsEmuCpuCore.Tick();
 
             Assert.Equal(ST1Value * Math.Log2(ST0Value), mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+
+        [Theory]
+        [InlineData(-4d, 5d)] // negative ST(0) is an invalid operand
+        [InlineData(double.NaN, 5d)]
+        [InlineData(4d, double.NaN)]
+        [InlineData(0d, 0d)] // 0 * log2(0) == 0 * -Infinity, indeterminate
+        [InlineData(double.PositiveInfinity, 0d)] // 0 * log2(+Infinity) == 0 * +Infinity, indeterminate
+        public void FYL2X_InvalidOperand_ReturnsNaNAndSetsInvalidOperationFlag(double ST0Value, double ST1Value)
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(1);
+            mbbsEmuCpuCore.FpuStack[1] = ST0Value; //ST0
+            mbbsEmuCpuCore.FpuStack[0] = ST1Value; //ST1
+
+            var instructions = new Assembler(16);
+            instructions.fyl2x();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(double.NaN, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+            Assert.True(mbbsEmuCpuRegisters.Fpu.ControlWord.IsFlagSet((ushort)EnumFpuControlWordFlags.InvalidOperation));
         }
     }
 }

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -4929,12 +4929,24 @@ namespace MBBSEmu.CPU
         ///     Floating Point Operation (x87)
         ///
         ///     Computes (ST(1) * log2(ST(0))), stores the result in ST(1), and pops the FPU register stack.
+        ///     ST(0) must be positive and neither operand may be NaN; per the x87 spec, a negative or NaN
+        ///     ST(0)/ST(1), or an indeterminate 0 * Infinity combination, is an invalid operation and yields
+        ///     a NaN result (the stack still pops).
         /// </summary>
         [MethodImpl(OpcodeCompilerOptimizations)]
         private void Op_Fyl2x()
         {
             var ST0x = FpuStack[Registers.Fpu.GetStackTop()];
             var ST1y = FpuStack[Registers.Fpu.GetStackPointer(Register.ST1)];
+
+            if (double.IsNaN(ST0x) || double.IsNaN(ST1y) || ST0x < 0 ||
+                (ST0x == 0 && ST1y == 0) || (double.IsPositiveInfinity(ST0x) && ST1y == 0))
+            {
+                FpuStack[Registers.Fpu.GetStackPointer(Register.ST1)] = double.NaN;
+                Registers.Fpu.ControlWord = Registers.Fpu.ControlWord.SetFlag((ushort)EnumFpuControlWordFlags.InvalidOperation);
+                Registers.Fpu.PopStackTop();
+                return;
+            }
 
             FpuStack[Registers.Fpu.GetStackPointer(Register.ST1)] = ST1y * Math.Log2(ST0x);
 
@@ -4945,14 +4957,26 @@ namespace MBBSEmu.CPU
         ///     Floating Point Operation (x87)
         ///
         ///     Computes (ST(1) * log2(ST(0) + 1.0)), stores the result in ST(1), and pops the FPU register stack.
+        ///     Same invalid-operation guards as FYL2X, applied to (ST(0) + 1.0) since that is the value being
+        ///     passed to log2.
         /// </summary>
         [MethodImpl(OpcodeCompilerOptimizations)]
         private void Op_Fyl2xp1()
         {
             var ST0x = FpuStack[Registers.Fpu.GetStackTop()];
             var ST1y = FpuStack[Registers.Fpu.GetStackPointer(Register.ST1)];
+            var argument = ST0x + 1.0;
 
-            FpuStack[Registers.Fpu.GetStackPointer(Register.ST1)] = ST1y * Math.Log2(ST0x + 1.0);
+            if (double.IsNaN(ST0x) || double.IsNaN(ST1y) || argument < 0 ||
+                (argument == 0 && ST1y == 0) || (double.IsPositiveInfinity(argument) && ST1y == 0))
+            {
+                FpuStack[Registers.Fpu.GetStackPointer(Register.ST1)] = double.NaN;
+                Registers.Fpu.ControlWord = Registers.Fpu.ControlWord.SetFlag((ushort)EnumFpuControlWordFlags.InvalidOperation);
+                Registers.Fpu.PopStackTop();
+                return;
+            }
+
+            FpuStack[Registers.Fpu.GetStackPointer(Register.ST1)] = ST1y * Math.Log2(argument);
 
             Registers.Fpu.PopStackTop();
         }

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -791,6 +791,48 @@ namespace MBBSEmu.CPU
                 case Mnemonic.Cdq:
                     Op_Cdq();
                     break;
+                case Mnemonic.Fabs:
+                    Op_Fabs();
+                    break;
+                case Mnemonic.Fsincos:
+                    Op_Fsincos();
+                    break;
+                case Mnemonic.Fxtract:
+                    Op_Fxtract();
+                    break;
+                case Mnemonic.Fprem:
+                    Op_Fprem();
+                    break;
+                case Mnemonic.F2xm1:
+                    Op_F2xm1();
+                    break;
+                case Mnemonic.Fyl2x:
+                    Op_Fyl2x();
+                    break;
+                case Mnemonic.Fyl2xp1:
+                    Op_Fyl2xp1();
+                    break;
+                case Mnemonic.Fptan:
+                    Op_Fptan();
+                    break;
+                case Mnemonic.Fldl2e:
+                    Op_Fldl2e();
+                    break;
+                case Mnemonic.Fldln2:
+                    Op_Fldln2();
+                    break;
+                case Mnemonic.Fldlg2:
+                    Op_Fldlg2();
+                    break;
+                case Mnemonic.Fldl2t:
+                    Op_Fldl2t();
+                    break;
+                case Mnemonic.Fincstp:
+                    Op_Fincstp();
+                    break;
+                case Mnemonic.Fdecstp:
+                    Op_Fdecstp();
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException($"Unsupported OpCode: {_currentInstruction.Mnemonic}");
             }
@@ -4770,6 +4812,234 @@ namespace MBBSEmu.CPU
         private void Op_Fchs()
         {
             FpuStack[Registers.Fpu.GetStackTop()] = -FpuStack[Registers.Fpu.GetStackTop()];
+        }
+
+        /// <summary>
+        ///     Floating Point Operation (x87)
+        ///
+        ///     Computes the absolute value of ST(0) and stores the result in ST(0).
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Fabs()
+        {
+            FpuStack[Registers.Fpu.GetStackTop()] = Math.Abs(FpuStack[Registers.Fpu.GetStackTop()]);
+        }
+
+        /// <summary>
+        ///     Floating Point Operation (x87)
+        ///
+        ///     Computes both the sine and the cosine of ST(0), stores the sine in ST(0), and pushes the cosine onto the register stack.
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Fsincos()
+        {
+            var value = FpuStack[Registers.Fpu.GetStackTop()];
+
+            switch (value)
+            {
+                case double.PositiveInfinity:
+                case double.NegativeInfinity:
+                    throw new ArgumentOutOfRangeException("Invalid Floating Point: Infinity");
+                case double.NaN:
+                    return;
+            }
+
+            FpuStack[Registers.Fpu.GetStackTop()] = Math.Sin(value);
+            Registers.Fpu.PushStackTop();
+            FpuStack[Registers.Fpu.GetStackTop()] = Math.Cos(value);
+            Registers.Fpu.ClearFlag(EnumFpuStatusFlags.Code2);
+        }
+
+        /// <summary>
+        ///     Floating Point Operation (x87)
+        ///
+        ///     Separates ST(0) into its exponent and significand, stores the significand (in the range [1, 2)) in ST(0),
+        ///     and pushes the unbiased exponent onto the register stack.
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Fxtract()
+        {
+            var value = FpuStack[Registers.Fpu.GetStackTop()];
+
+            double exponent;
+            double significand;
+            switch (value)
+            {
+                case 0:
+                    exponent = double.NegativeInfinity;
+                    significand = value;
+                    Registers.Fpu.ControlWord = Registers.Fpu.ControlWord.SetFlag((ushort)EnumFpuControlWordFlags.ZeroDivide);
+                    break;
+                case double.NaN:
+                case double.PositiveInfinity:
+                case double.NegativeInfinity:
+                    exponent = value;
+                    significand = value;
+                    break;
+                default:
+                    var unbiasedExponent = Math.ILogB(value);
+                    exponent = unbiasedExponent;
+                    significand = Math.ScaleB(value, -unbiasedExponent);
+                    break;
+            }
+
+            FpuStack[Registers.Fpu.GetStackTop()] = exponent;
+            Registers.Fpu.PushStackTop();
+            FpuStack[Registers.Fpu.GetStackTop()] = significand;
+        }
+
+        /// <summary>
+        ///     Floating Point Operation (x87)
+        ///
+        ///     Computes the partial remainder obtained from dividing ST(0) by ST(1) and stores the result in ST(0).
+        ///     The result has the same sign as the dividend ST(0), matching the semantics of the C runtime's fmod().
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Fprem()
+        {
+            var ST0 = FpuStack[Registers.Fpu.GetStackTop()];
+            var ST1 = FpuStack[Registers.Fpu.GetStackPointer(Register.ST1)];
+
+            if (double.IsNaN(ST0) || double.IsNaN(ST1) || double.IsInfinity(ST0) || ST1 == 0)
+            {
+                FpuStack[Registers.Fpu.GetStackTop()] = double.NaN;
+                Registers.Fpu.ControlWord = Registers.Fpu.ControlWord.SetFlag((ushort)EnumFpuControlWordFlags.InvalidOperation);
+                return;
+            }
+
+            if (double.IsInfinity(ST1))
+                return;
+
+            FpuStack[Registers.Fpu.GetStackTop()] = ST0 % ST1;
+            Registers.Fpu.ClearFlag(EnumFpuStatusFlags.Code2);
+        }
+
+        /// <summary>
+        ///     Floating Point Operation (x87)
+        ///
+        ///     Computes 2^ST(0) - 1 and stores the result in ST(0). Valid for ST(0) in the range [-1, 1].
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_F2xm1()
+        {
+            FpuStack[Registers.Fpu.GetStackTop()] = Math.Pow(2, FpuStack[Registers.Fpu.GetStackTop()]) - 1;
+        }
+
+        /// <summary>
+        ///     Floating Point Operation (x87)
+        ///
+        ///     Computes (ST(1) * log2(ST(0))), stores the result in ST(1), and pops the FPU register stack.
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Fyl2x()
+        {
+            var ST0x = FpuStack[Registers.Fpu.GetStackTop()];
+            var ST1y = FpuStack[Registers.Fpu.GetStackPointer(Register.ST1)];
+
+            FpuStack[Registers.Fpu.GetStackPointer(Register.ST1)] = ST1y * Math.Log2(ST0x);
+
+            Registers.Fpu.PopStackTop();
+        }
+
+        /// <summary>
+        ///     Floating Point Operation (x87)
+        ///
+        ///     Computes (ST(1) * log2(ST(0) + 1.0)), stores the result in ST(1), and pops the FPU register stack.
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Fyl2xp1()
+        {
+            var ST0x = FpuStack[Registers.Fpu.GetStackTop()];
+            var ST1y = FpuStack[Registers.Fpu.GetStackPointer(Register.ST1)];
+
+            FpuStack[Registers.Fpu.GetStackPointer(Register.ST1)] = ST1y * Math.Log2(ST0x + 1.0);
+
+            Registers.Fpu.PopStackTop();
+        }
+
+        /// <summary>
+        ///     Floating Point Operation (x87)
+        ///
+        ///     Computes the tangent of ST(0), stores the result in ST(0), and pushes a 1.0 onto the register stack.
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Fptan()
+        {
+            var value = FpuStack[Registers.Fpu.GetStackTop()];
+
+            switch (value)
+            {
+                case double.PositiveInfinity:
+                case double.NegativeInfinity:
+                    throw new ArgumentOutOfRangeException("Invalid Floating Point: Infinity");
+                case double.NaN:
+                    return;
+            }
+
+            FpuStack[Registers.Fpu.GetStackTop()] = Math.Tan(value);
+            Registers.Fpu.PushStackTop();
+            FpuStack[Registers.Fpu.GetStackTop()] = 1d;
+        }
+
+        /// <summary>
+        ///     Pushes log2(e) onto the FPU register stack.
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Fldl2e()
+        {
+            Registers.Fpu.PushStackTop();
+            FpuStack[Registers.Fpu.GetStackTop()] = 1.4426950408889634d;
+        }
+
+        /// <summary>
+        ///     Pushes ln(2) onto the FPU register stack.
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Fldln2()
+        {
+            Registers.Fpu.PushStackTop();
+            FpuStack[Registers.Fpu.GetStackTop()] = 0.6931471805599453d;
+        }
+
+        /// <summary>
+        ///     Pushes log10(2) onto the FPU register stack.
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Fldlg2()
+        {
+            Registers.Fpu.PushStackTop();
+            FpuStack[Registers.Fpu.GetStackTop()] = 0.3010299956639812d;
+        }
+
+        /// <summary>
+        ///     Pushes log2(10) onto the FPU register stack.
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Fldl2t()
+        {
+            Registers.Fpu.PushStackTop();
+            FpuStack[Registers.Fpu.GetStackTop()] = 3.3219280948873623d;
+        }
+
+        /// <summary>
+        ///     Increments the FPU stack pointer without storing a value, equivalent to discarding ST(0)
+        ///     and promoting ST(1) to ST(0). Our internal stack-top counter runs in the opposite direction
+        ///     of the physical x87 TOP field, so this maps to PopStackTop() (see Fpatan/Fyl2x for the same pattern).
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Fincstp()
+        {
+            Registers.Fpu.PopStackTop();
+        }
+
+        /// <summary>
+        ///     Decrements the FPU stack pointer without storing a value, making room for a new ST(0)
+        ///     and demoting the old ST(0) to ST(1). Maps to PushStackTop() for the same reason as Op_Fincstp().
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Fdecstp()
+        {
+            Registers.Fpu.PushStackTop();
         }
 
         /// <summary>


### PR DESCRIPTION
- FABS, FSINCOS, FXTRACT, FPREM — the four opcodes the issue explicitly reports as crashing modules with "Unsupported OpCode" (used by sinh, tan, tanh, frexp, fmod)
- F2XM1, FYL2X, FYL2XP1, FPTAN, FLDL2E, FLDLN2, FLDLG2, FLDL2T — these were also entirely missing, and are the building blocks the compiled runtime uses for exp, log, log10, pow, atan2, cosh (explaining why those "ran but returned wrong/unchanged values" — the compiler-generated code was hitting no-ops or falling through incorrectly before this)
- FINCSTP/FDECSTP — stack-pointer adjustment opcodes commonly paired with FXTRACT/FPREM sequences**