### PR TITLE
Fix FLD/FSTP tbyte (80-bit) operands being read/written as 8-byte doubles

### DIFF
--- a/MBBSEmu.Tests/CPU/FLD_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FLD_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using Iced.Intel;
 using System;
+using System.Collections.Generic;
 using Xunit;
 using static Iced.Intel.AssemblerRegisters;
 
@@ -96,6 +97,67 @@ namespace MBBSEmu.Tests.CPU
 
             Assert.Equal(st0, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
             Assert.Equal(st1, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackPointer(Register.ST1)]);
+        }
+
+        public static IEnumerable<object[]> M80TestData => new List<object[]>
+        {
+            new object[] { new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, 0.0d }, //+0.0
+            new object[] { new byte[] { 0, 0, 0, 0, 0, 0, 0, 0x80, 0xFF, 0x3F }, 1.0d },
+            new object[] { new byte[] { 0, 0, 0, 0, 0, 0, 0, 0x80, 0xFF, 0xBF }, -1.0d },
+            new object[] { new byte[] { 0, 0, 0, 0, 0, 0, 0, 0x80, 0x00, 0x40 }, 2.0d },
+            new object[] { new byte[] { 0, 0, 0, 0, 0, 0, 0, 0x80, 0xFE, 0x3F }, 0.5d },
+        };
+
+        [Theory]
+        [MemberData(nameof(M80TestData))]
+        public void FLD_Test_M80(byte[] tbyteValue, double expectedValue)
+        {
+            Reset();
+
+            CreateDataSegment(new ReadOnlySpan<byte>(), 2);
+            mbbsEmuMemoryCore.SetArray(2, 0, tbyteValue);
+            mbbsEmuCpuRegisters.DS = 2;
+
+            var instructions = new Assembler(16);
+            instructions.fld(__tbyte_ptr[0]);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(expectedValue, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+
+        [Theory]
+        [InlineData(0.0d)]
+        [InlineData(1.0d)]
+        [InlineData(-1.0d)]
+        [InlineData(double.MaxValue)]
+        [InlineData(double.MinValue)]
+        [InlineData(double.Epsilon)]
+        [InlineData(double.PositiveInfinity)]
+        [InlineData(double.NegativeInfinity)]
+        [InlineData(double.NaN)]
+        [InlineData(1e32)]
+        [InlineData(-1e300)]
+        [InlineData(Math.PI)]
+        public void FLD_FSTP_M80_RoundTrip(double value)
+        {
+            Reset();
+
+            CreateDataSegment(new ReadOnlySpan<byte>(), 2);
+            mbbsEmuCpuRegisters.DS = 2;
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(0);
+            mbbsEmuCpuCore.FpuStack[0] = value;
+
+            var instructions = new Assembler(16);
+            instructions.fstp(__tbyte_ptr[0]);
+            instructions.fld(__tbyte_ptr[0]);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(value, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
         }
 
         [Theory]

--- a/MBBSEmu.Tests/CPU/FSTP_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FSTP_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using Iced.Intel;
 using System;
+using System.Collections.Generic;
 using Xunit;
 using static Iced.Intel.AssemblerRegisters;
 
@@ -71,6 +72,35 @@ namespace MBBSEmu.Tests.CPU
             mbbsEmuCpuCore.Tick();
 
             Assert.Equal(ST0Value, BitConverter.ToDouble(mbbsEmuMemoryCore.GetArray(2, 0, 8)));
+            Assert.Equal(7, mbbsEmuCpuRegisters.Fpu.GetStackTop());
+        }
+
+        public static IEnumerable<object[]> M80TestData => new List<object[]>
+        {
+            new object[] { 0.0d, new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } }, //+0.0
+            new object[] { 1.0d, new byte[] { 0, 0, 0, 0, 0, 0, 0, 0x80, 0xFF, 0x3F } },
+            new object[] { -1.0d, new byte[] { 0, 0, 0, 0, 0, 0, 0, 0x80, 0xFF, 0xBF } },
+            new object[] { 2.0d, new byte[] { 0, 0, 0, 0, 0, 0, 0, 0x80, 0x00, 0x40 } },
+            new object[] { 0.5d, new byte[] { 0, 0, 0, 0, 0, 0, 0, 0x80, 0xFE, 0x3F } },
+        };
+
+        [Theory]
+        [MemberData(nameof(M80TestData))]
+        public void FSTP_Test_M80(double ST0Value, byte[] expectedTbyteValue)
+        {
+            Reset();
+            CreateDataSegment(new ReadOnlySpan<byte>(), 2);
+            mbbsEmuCpuRegisters.DS = 2;
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(0);
+            mbbsEmuCpuCore.FpuStack[0] = ST0Value;
+
+            var instructions = new Assembler(16);
+            instructions.fstp(__tbyte_ptr[0]);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(expectedTbyteValue, mbbsEmuMemoryCore.GetArray(2, 0, 10));
             Assert.Equal(7, mbbsEmuCpuRegisters.Fpu.GetStackTop());
         }
     }

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 
 namespace MBBSEmu.CPU
@@ -1206,15 +1207,94 @@ namespace MBBSEmu.CPU
                 OpKind.Memory when _currentInstruction.MemorySize == MemorySize.Float64 => BitConverter.ToDouble(
                     Memory.GetArray(Registers.GetValue(_currentInstruction.MemorySegment), GetOperandOffset(opKind),
                         8)),
-                OpKind.Memory when _currentInstruction.MemorySize == MemorySize.Float80 => BitConverter.ToDouble(
+                OpKind.Memory when _currentInstruction.MemorySize == MemorySize.Float80 => Float80BytesToDouble(
                     Memory.GetArray(Registers.GetValue(_currentInstruction.MemorySegment), GetOperandOffset(opKind),
-                        8)),
+                        10)),
                 OpKind.Register when operandType == EnumOperandType.Destination => FpuStack[
                     Registers.Fpu.GetStackPointer(_currentInstruction.Op0Register)],
                 OpKind.Register when operandType == EnumOperandType.Source => FpuStack[
                     Registers.Fpu.GetStackPointer(_currentInstruction.Op1Register)],
                 _ => throw new Exception($"Unknown Double Operand: {opKind}")
             };
+        }
+
+        /// <summary>
+        ///     Decodes a 10-byte x87 80-bit extended precision value (as read from memory, little-endian)
+        ///     into the closest representable 64-bit Double.
+        ///
+        ///     Format: bytes[0..7] are the 64-bit mantissa (with an explicit integer bit at bit 63),
+        ///     bytes[8..9] are a 15-bit biased exponent (bias 16383) plus the sign bit (bit 15).
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private static double Float80BytesToDouble(ReadOnlySpan<byte> bytes)
+        {
+            var mantissa = BitConverter.ToUInt64(bytes.Slice(0, 8));
+            var signAndExponent = BitConverter.ToUInt16(bytes.Slice(8, 2));
+            var exponent = signAndExponent & 0x7FFF;
+            var isNegative = (signAndExponent & 0x8000) != 0;
+
+            if (exponent == 0 && mantissa == 0)
+                return isNegative ? -0.0 : 0.0;
+
+            if (exponent == 0x7FFF)
+            {
+                //Fraction bits set (ignoring the explicit integer bit) indicates a NaN, otherwise Infinity
+                if ((mantissa & 0x7FFFFFFFFFFFFFFF) != 0)
+                    return double.NaN;
+
+                return isNegative ? double.NegativeInfinity : double.PositiveInfinity;
+            }
+
+            //Unnormal/denormal 80-bit values (exponent == 0) use the smallest normal exponent with no implicit bit
+            var unbiasedExponent = exponent == 0 ? 1 - 16383 : exponent - 16383;
+
+            var result = Math.ScaleB((double)mantissa, unbiasedExponent - 63);
+            return isNegative ? -result : result;
+        }
+
+        /// <summary>
+        ///     Encodes a 64-bit Double into a 10-byte x87 80-bit extended precision value (little-endian),
+        ///     suitable for writing to memory via FST/FSTP.
+        /// </summary>
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private static void DoubleToFloat80Bytes(double value, Span<byte> destination)
+        {
+            var bits = BitConverter.DoubleToInt64Bits(value);
+            var isNegative = bits < 0;
+            var biasedExponent = (int)((bits >> 52) & 0x7FF);
+            var fraction = (ulong)bits & 0xFFFFFFFFFFFFFUL;
+
+            ulong mantissa80;
+            int exponent80;
+
+            if (biasedExponent == 0x7FF)
+            {
+                //Infinity or NaN
+                exponent80 = 0x7FFF;
+                mantissa80 = fraction == 0 ? 0x8000000000000000UL : 0xC000000000000000UL | (fraction << 11);
+            }
+            else if (biasedExponent == 0 && fraction == 0)
+            {
+                //Zero
+                exponent80 = 0;
+                mantissa80 = 0;
+            }
+            else
+            {
+                //Normal doubles have an implicit integer bit; denormals do not and use the minimum exponent
+                var significand = biasedExponent == 0 ? fraction : fraction | (1UL << 52);
+                var unbiasedExponent = biasedExponent == 0 ? -1022 : biasedExponent - 1023;
+
+                //Normalize so the explicit integer bit lands at bit 63
+                var shift = BitOperations.LeadingZeroCount(significand);
+                mantissa80 = significand << shift;
+                exponent80 = unbiasedExponent + 11 - shift + 16383;
+            }
+
+            var signAndExponent = (ushort)((exponent80 & 0x7FFF) | (isNegative ? 0x8000 : 0));
+
+            BitConverter.TryWriteBytes(destination, mantissa80);
+            BitConverter.TryWriteBytes(destination.Slice(8, 2), signAndExponent);
         }
 
         /// <summary>
@@ -3796,11 +3876,17 @@ namespace MBBSEmu.CPU
                         Memory.SetArray(Registers.GetValue(_currentInstruction.MemorySegment), GetOperandOffset(_currentInstruction.Op0Kind), bytes);
                         break;
                     }
-                case OpKind.Memory when _currentInstruction.MemorySize == MemorySize.Float80:
                 case OpKind.Memory when _currentInstruction.MemorySize == MemorySize.Float64:
                     {
                         Span<byte> bytes = stackalloc byte[8];
                         BitConverter.TryWriteBytes(bytes, valueToSave);
+                        Memory.SetArray(Registers.GetValue(_currentInstruction.MemorySegment), GetOperandOffset(_currentInstruction.Op0Kind), bytes);
+                        break;
+                    }
+                case OpKind.Memory when _currentInstruction.MemorySize == MemorySize.Float80:
+                    {
+                        Span<byte> bytes = stackalloc byte[10];
+                        DoubleToFloat80Bytes(valueToSave, bytes);
                         Memory.SetArray(Registers.GetValue(_currentInstruction.MemorySegment), GetOperandOffset(_currentInstruction.Op0Kind), bytes);
                         break;
                     }


### PR DESCRIPTION
Fixes #682

FLD and FSTP with an 80-bit x87 extended-precision memory operand were reading/writing only 8 bytes via BitConverter.ToDouble/TryWriteBytes, misinterpreting the extended format's explicit integer bit as the double's sign bit. This made every normalized `FLD tbyte` load as negative and silently truncated `FSTP tbyte` writes to 8 bytes.

Added `Float80BytesToDouble`/`DoubleToFloat80Bytes` to properly decode and encode the 10-byte extended format (64-bit mantissa with explicit integer bit + 15-bit biased exponent + sign), including zero, infinity, NaN, and denormal handling.

## Test plan
- Added `FLD_Test_M80`/`FSTP_Test_M80` with hand-verified 80-bit byte patterns (0, ±1, 2, 0.5)
- Added `FLD_FSTP_M80_RoundTrip` covering double.MaxValue/MinValue/Epsilon, ±Infinity, NaN, 1e32, -1e300, π
- Full suite: 2680/2680 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HvMWCgKyMzSFCFh7Nin2dP