### PR TITLE
perf(cpu): bulk-copy fast path for forward REP MOVSB/MOVSW/STOSB

### DIFF
--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -3855,10 +3855,29 @@ namespace MBBSEmu.CPU
 
         /// <summary>
         ///     Store AL at address ES:(E)DI.
+        ///
+        ///     For a forward (DF=0) REP STOSB that stays within its segment, fills the whole
+        ///     run in one shot via Memory.FillArray instead of looping byte-by-byte.
         /// </summary>
         [MethodImpl(OpcodeCompilerOptimizations)]
         private void Op_Stosb()
         {
+            if (IsRepInstruction() && !Registers.DirectionFlag && !_currentInstruction.HasRepnePrefix)
+            {
+                var count = Registers.CX;
+                if ((uint)Registers.DI + count <= 0x10000)
+                {
+                    if (count > 0)
+                    {
+                        Memory.FillArray(Registers.ES, Registers.DI, count, Registers.AL);
+                        Registers.DI += count;
+                    }
+
+                    Registers.CX = 0;
+                    return;
+                }
+            }
+
             Repeat(() =>
             {
                 Memory.SetByte(Registers.ES, Registers.DI, Registers.AL);
@@ -4572,11 +4591,34 @@ namespace MBBSEmu.CPU
         }
 
         /// <summary>
-        ///     Move data from String to String. TODO we can probably optimize this to copy as a chunk
+        ///     Move data from String to String
+        ///
+        ///     For a forward (DF=0) REP MOVSB that stays within its segments, copies the whole
+        ///     run in one shot via Memory.GetArray/SetArray instead of looping byte-by-byte.
+        ///     Falls back to the byte-at-a-time path for the backward-direction, unprefixed,
+        ///     or segment-wraparound cases so behavior is unchanged there.
         /// </summary>
         [MethodImpl(OpcodeCompilerOptimizations)]
         private void Op_Movsb()
         {
+            if (IsRepInstruction() && !Registers.DirectionFlag && !_currentInstruction.HasRepnePrefix)
+            {
+                var count = Registers.CX;
+                if ((uint)Registers.SI + count <= 0x10000 && (uint)Registers.DI + count <= 0x10000)
+                {
+                    if (count > 0)
+                    {
+                        var source = Memory.GetArray(Registers.DS, Registers.SI, count);
+                        Memory.SetArray(Registers.ES, Registers.DI, source);
+                        Registers.SI += count;
+                        Registers.DI += count;
+                    }
+
+                    Registers.CX = 0;
+                    return;
+                }
+            }
+
             Repeat(() =>
             {
                 Memory.SetByte(Registers.ES, Registers.DI, Memory.GetByte(Registers.DS, Registers.SI));
@@ -4595,11 +4637,32 @@ namespace MBBSEmu.CPU
         }
 
         /// <summary>
-        ///     Move data from String to String. TODO we can probably optimize this to copy as a chunk
+        ///     Move data from String to String
+        ///
+        ///     Same forward-run bulk-copy fast path as <see cref="Op_Movsb"/>, sized in words.
         /// </summary>
         [MethodImpl(OpcodeCompilerOptimizations)]
         private void Op_Movsw()
         {
+            if (IsRepInstruction() && !Registers.DirectionFlag && !_currentInstruction.HasRepnePrefix)
+            {
+                var count = Registers.CX;
+                var byteCount = count * 2;
+                if (byteCount <= ushort.MaxValue && (uint)Registers.SI + byteCount <= 0x10000 && (uint)Registers.DI + byteCount <= 0x10000)
+                {
+                    if (count > 0)
+                    {
+                        var source = Memory.GetArray(Registers.DS, Registers.SI, (ushort)byteCount);
+                        Memory.SetArray(Registers.ES, Registers.DI, source);
+                        Registers.SI += (ushort)byteCount;
+                        Registers.DI += (ushort)byteCount;
+                    }
+
+                    Registers.CX = 0;
+                    return;
+                }
+            }
+
             Repeat(() =>
             {
                 Memory.SetWord(Registers.ES, Registers.DI, Memory.GetWord(Registers.DS, Registers.SI));


### PR DESCRIPTION
## Summary
- `Op_Movsb`/`Op_Movsw`/`Op_Stosb` executed REP-prefixed runs through a per-element closure (`Repeat`/`Op_Rep`), with a long-standing `// TODO we can probably optimize this to copy as a chunk` comment on the loop.
- Adds a fast path for the common case — forward direction (`DF=0`), a real `REP` prefix (not a stray `REPNE`), and a run that stays within its segment — that performs the whole run in one call via `Memory.GetArray`/`SetArray` (movs) or `Memory.FillArray` (stos) instead of looping byte-by-byte.
- Falls back to the original byte-at-a-time path for backward direction, malformed prefixes, or segment-wraparound runs, so behavior is unchanged there.

## Performance
Benchmarked with a standalone `Tick()`-driving harness (A/B swapped binaries, alternating runs to rule out noise/drift):
- ~10-13x throughput on 512-byte REP MOVSB/STOSB workloads
- ~1.5-1.8x on small 32-byte runs
- No measurable change on non-string workloads (arithmetic/jump mix, memory, FPU)

## Test plan
- [x] `dotnet test` — full suite passes (2624/2624), including `MOVSB_Tests.memcpy` which exercises a real `rep movsw`+`movsb` memcpy sequence through this path
- [x] `dotnet build` — solution builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DK2XAhPFBAWg6Q1S7TZyRC