### PR TITLE
Implement parity flag and JP/JNP instructions

### DIFF
--- a/MBBSEmu.Tests/CPU/FPREM_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FPREM_Tests.cs
@@ -25,5 +25,27 @@ namespace MBBSEmu.Tests.CPU
 
             Assert.Equal(ST0Value % ST1Value, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
         }
+
+        [Fact]
+        public void FPREM_BorlandFmodSequence()
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(1);
+            mbbsEmuCpuCore.FpuStack[1] = 5.3d; // ST0
+            mbbsEmuCpuCore.FpuStack[0] = 2d; // ST1
+
+            // FPREM; FNSTSW AX; SAHF; JP back to FPREM
+            CreateCodeSegment(new byte[] { 0xD9, 0xF8, 0xDF, 0xE0, 0x9E, 0x7A, 0xF9 });
+
+            mbbsEmuCpuCore.Tick();
+            mbbsEmuCpuCore.Tick();
+            mbbsEmuCpuCore.Tick();
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(5.3d % 2d, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+            Assert.False(mbbsEmuCpuRegisters.ParityFlag);
+            Assert.Equal(7, mbbsEmuCpuRegisters.IP);
+        }
     }
 }

--- a/MBBSEmu.Tests/CPU/IRET_Tests.cs
+++ b/MBBSEmu.Tests/CPU/IRET_Tests.cs
@@ -24,7 +24,7 @@ namespace MBBSEmu.Tests.CPU
 
             Assert.Equal(0xFFFD, mbbsEmuCpuRegisters.IP);
             Assert.Equal(0xFFFE, mbbsEmuCpuRegisters.CS);
-            Assert.Equal(0xED1, mbbsEmuCpuRegisters.F);
+            Assert.Equal(0xED5, mbbsEmuCpuRegisters.F);
             Assert.Equal(entrySP, mbbsEmuCpuRegisters.SP);
         }
     }

--- a/MBBSEmu.Tests/CPU/JP_JNP_Tests.cs
+++ b/MBBSEmu.Tests/CPU/JP_JNP_Tests.cs
@@ -1,0 +1,74 @@
+﻿using Iced.Intel;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class JP_JNP_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(true, 0)]
+        [InlineData(false, 2)]
+        public void JP_Test(bool parityFlagValue, ushort ipValue)
+        {
+            Reset();
+
+            var instructions = new Assembler(16);
+            instructions.jp(0);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuRegisters.ParityFlag = parityFlagValue;
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(ipValue, mbbsEmuCpuRegisters.IP);
+            Assert.Equal(parityFlagValue, mbbsEmuCpuRegisters.ParityFlag);
+        }
+
+        [Theory]
+        [InlineData(true, 2)]
+        [InlineData(false, 0)]
+        public void JNP_Test(bool parityFlagValue, ushort ipValue)
+        {
+            Reset();
+
+            var instructions = new Assembler(16);
+            instructions.jnp(0);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuRegisters.ParityFlag = parityFlagValue;
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(ipValue, mbbsEmuCpuRegisters.IP);
+            Assert.Equal(parityFlagValue, mbbsEmuCpuRegisters.ParityFlag);
+        }
+
+        [Theory]
+        [InlineData(0x00, true)]
+        [InlineData(0x01, false)]
+        [InlineData(0x03, true)]
+        [InlineData(0xFF, true)]
+        public void LogicalOperation_EvaluatesParity(byte value, bool expected)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AL = value;
+            CreateCodeSegment(new byte[] { 0x34, 0x00 }); // XOR AL, 0
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(expected, mbbsEmuCpuRegisters.ParityFlag);
+        }
+
+        [Theory]
+        [InlineData(0x04, true)]
+        [InlineData(0x00, false)]
+        public void SAHF_LoadsParityFlag(byte ah, bool expected)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AH = ah;
+            CreateCodeSegment(new byte[] { 0x9E }); // SAHF
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(expected, mbbsEmuCpuRegisters.ParityFlag);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/POPF_Tests.cs
+++ b/MBBSEmu.Tests/CPU/POPF_Tests.cs
@@ -21,7 +21,7 @@ namespace MBBSEmu.Tests.CPU
 
             mbbsEmuCpuCore.Tick();
 
-            Assert.Equal(0x0ED1, mbbsEmuCpuRegisters.F);
+            Assert.Equal(0x0ED5, mbbsEmuCpuRegisters.F);
             Assert.Equal(originalSP, mbbsEmuCpuRegisters.SP);
         }
 
@@ -42,7 +42,7 @@ namespace MBBSEmu.Tests.CPU
             mbbsEmuCpuCore.Tick();
 
             // subset of all the flags
-            Assert.Equal(0x00000ED1, mbbsEmuCpuRegisters.F);
+            Assert.Equal(0x00000ED5, mbbsEmuCpuRegisters.F);
             Assert.Equal(originalSP, mbbsEmuCpuRegisters.SP);
         }
     }

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -442,6 +442,12 @@ namespace MBBSEmu.CPU
                 case Mnemonic.Jg:
                     Op_Jg();
                     return;
+                case Mnemonic.Jp:
+                    Op_Jp();
+                    return;
+                case Mnemonic.Jnp:
+                    Op_Jnp();
+                    return;
                 case Mnemonic.Js:
                     Op_Js();
                     return;
@@ -2758,6 +2764,32 @@ namespace MBBSEmu.CPU
         }
 
         [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Jp()
+        {
+            if (Registers.ParityFlag)
+            {
+                Registers.IP = _currentInstruction.Immediate16;
+            }
+            else
+            {
+                Registers.IP += (ushort)_currentInstruction.Length;
+            }
+        }
+
+        [MethodImpl(OpcodeCompilerOptimizations)]
+        private void Op_Jnp()
+        {
+            if (!Registers.ParityFlag)
+            {
+                Registers.IP = _currentInstruction.Immediate16;
+            }
+            else
+            {
+                Registers.IP += (ushort)_currentInstruction.Length;
+            }
+        }
+
+        [MethodImpl(OpcodeCompilerOptimizations)]
         private void Op_Js()
         {
             //SF == 1
@@ -3604,6 +3636,7 @@ namespace MBBSEmu.CPU
         private void Op_Sahf()
         {
             Registers.SignFlag = Registers.AH.IsFlagSet((byte)EnumFlags.SF);
+            Registers.ParityFlag = Registers.AH.IsFlagSet((byte)EnumFlags.PF);
             Registers.ZeroFlag = Registers.AH.IsFlagSet((byte)EnumFlags.ZF);
             Registers.AuxiliaryCarryFlag = Registers.AH.IsFlagSet((byte)EnumFlags.AF);
             Registers.CarryFlag = Registers.AH.IsFlagSet((byte)EnumFlags.CF);
@@ -5736,6 +5769,7 @@ namespace MBBSEmu.CPU
         [MethodImpl(OpcodeCompilerOptimizations)]
         private void Flags_EvaluateSignZero(byte result)
         {
+            Registers.ParityFlag = result.Parity();
             if (result == 0)
             {
                 Registers.SignFlag = false;
@@ -5755,6 +5789,7 @@ namespace MBBSEmu.CPU
         [MethodImpl(OpcodeCompilerOptimizations)]
         private void Flags_EvaluateSignZero(ushort result)
         {
+            Registers.ParityFlag = result.Parity();
             if (result == 0)
             {
                 Registers.SignFlag = false;
@@ -5774,6 +5809,7 @@ namespace MBBSEmu.CPU
         [MethodImpl(OpcodeCompilerOptimizations)]
         private void Flags_EvaluateSignZero(uint result)
         {
+            Registers.ParityFlag = result.Parity();
             if (result == 0)
             {
                 Registers.SignFlag = false;

--- a/MBBSEmu/CPU/CpuRegisters.cs
+++ b/MBBSEmu/CPU/CpuRegisters.cs
@@ -48,6 +48,7 @@ namespace MBBSEmu.CPU
         public bool DirectionFlag { get => Registers.DirectionFlag; set => Registers.DirectionFlag = value; }
         public bool AuxiliaryCarryFlag { get => Registers.AuxiliaryCarryFlag; set => Registers.AuxiliaryCarryFlag = value; }
         public bool InterruptFlag { get => Registers.InterruptFlag; set => Registers.InterruptFlag = value; }
+        public bool ParityFlag { get => Registers.ParityFlag; set => Registers.ParityFlag = value; }
         public bool Halt { get => Registers.Halt; set => Registers.Halt = value; }
 
         public void Zero() => Registers.Zero();

--- a/MBBSEmu/CPU/ICpuRegisters.cs
+++ b/MBBSEmu/CPU/ICpuRegisters.cs
@@ -69,6 +69,7 @@ namespace MBBSEmu.CPU
         bool DirectionFlag { get; set; }
         bool AuxiliaryCarryFlag { get; set; }
         bool InterruptFlag { get; set; }
+        bool ParityFlag { get; set; }
         bool Halt { get; set; }
 
         void Zero();

--- a/MBBSEmu/CPU/RegistersStructs.cs
+++ b/MBBSEmu/CPU/RegistersStructs.cs
@@ -241,6 +241,8 @@ namespace MBBSEmu.CPU
 
         [FieldOffset(50)]
         public FpuRegistersStruct Fpu;
+        [FieldOffset(54)]
+        public bool ParityFlag;
 
         public ushort F()
         {
@@ -253,6 +255,7 @@ namespace MBBSEmu.CPU
             if (SignFlag) f |= (ushort)EnumFlags.SF;
             if (ZeroFlag) f |= (ushort)EnumFlags.ZF;
             if (InterruptFlag) f |= (ushort)EnumFlags.IF;
+            if (ParityFlag) f |= (ushort)EnumFlags.PF;
 
             return f;
         }
@@ -268,6 +271,7 @@ namespace MBBSEmu.CPU
             SignFlag = flags.IsFlagSet((ushort)EnumFlags.SF);
             ZeroFlag = flags.IsFlagSet((ushort)EnumFlags.ZF);
             InterruptFlag = flags.IsFlagSet((ushort)EnumFlags.IF);
+            ParityFlag = flags.IsFlagSet((ushort)EnumFlags.PF);
         }
 
         public void SetEF(uint flags) => SetF((ushort)flags);
@@ -548,6 +552,7 @@ namespace MBBSEmu.CPU
             output.AppendLine($"BP={this.BP:X4} ");
             output.Append("F=");
             output.Append(this.CarryFlag ? "C" : "c");
+            output.Append(this.ParityFlag ? "P" : "p");
             output.Append(this.ZeroFlag ? "Z" : "z");
             output.Append(this.SignFlag ? "S" : "s");
             output.Append(this.OverflowFlag ? "O" : "o");

--- a/MBBSEmu/Extensions/ByteExtensions.cs
+++ b/MBBSEmu/Extensions/ByteExtensions.cs
@@ -61,7 +61,7 @@ namespace MBBSEmu.Extensions
                 if (b.IsBitSet(i))
                     setBits++;
             }
-            return setBits != 0 && setBits % 2 == 0;
+            return setBits % 2 == 0;
         }
 
         /// <summary>

--- a/MBBSEmu/Extensions/UintExtensions.cs
+++ b/MBBSEmu/Extensions/UintExtensions.cs
@@ -65,7 +65,7 @@ namespace MBBSEmu.Extensions
                     setBits++;
             }
 
-            return setBits != 0 && setBits % 2 == 0;
+            return setBits % 2 == 0;
         }
     }
 }

--- a/MBBSEmu/Extensions/UshortExtensions.cs
+++ b/MBBSEmu/Extensions/UshortExtensions.cs
@@ -66,7 +66,7 @@ namespace MBBSEmu.Extensions
                     setBits++;
             }
 
-            return setBits != 0 && setBits % 2 == 0;
+            return setBits % 2 == 0;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- track the x86 parity flag in the CPU register state
- implement the `JP` and `JNP` conditional jumps
- propagate parity through `SAHF`, FLAGS operations, and arithmetic/logical result evaluation
- correct parity evaluation for zero, which has even parity

## Motivation

Borland's 16-bit `fmod()` implementation uses this instruction sequence:

```asm
FPREM
FNSTSW AX
SAHF
JP retry
```

MBBSEmu already supports the floating-point instructions, but execution stopped at `JP` with `Unsupported OpCode: Jp`. The parity flag was defined in `EnumFlags`, but was not stored or propagated by the CPU.

This implements standard x86 parity behavior rather than adding a workaround for a particular module.

## Testing

- all 1,179 CPU tests pass
- added direct tests for `JP`, `JNP`, `SAHF`, and parity evaluation
- added a regression test for the complete Borland-style `fmod()` instruction sequence
- verified with the affected Borland module
