### PR TITLE
Fix formatted output buffer lifecycle

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/outprf_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/outprf_Tests.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using MBBSEmu.Memory;
+using MBBSEmu.Module;
+using System;
+using System.Collections.Generic;
 using System.Text;
 using Xunit;
 
@@ -7,6 +10,9 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
     public class outprf_Tests : ExportedModuleTestBase
     {
         private const int OUTPRF_ORDINAL = 463;
+        private const int PRF_ORDINAL = 474;
+        private const int PRFMSG_ORDINAL = 476;
+        private const int PRFMLT_ORDINAL = 178;
 
         [Fact]
         public void outprf_InvalidChannel_Test()
@@ -43,13 +49,63 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, OUTPRF_ORDINAL, new List<ushort> { 0xFFFE });
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, OUTPRF_ORDINAL, new List<ushort> { 0xFFFD });
 
-            //PRFPTR should be untouched by outprf()
+            //PRFPTR and PRFBUF remain intact for repeated sends
             var prfPtrAfter = mbbsEmuMemoryCore.GetPointer("PRFPTR");
             Assert.Equal(prfPtrBefore, prfPtrAfter);
 
             //PRFBUF contents should still be intact (not zeroed out)
             var prfBufAfter = mbbsEmuMemoryCore.GetString(prfBufPointerBefore, stripNull: true);
             Assert.Equal(inputValue, Encoding.ASCII.GetString(prfBufAfter));
+        }
+
+        [Fact]
+        public void prf_AfterOutprfStartsNewBuffer_Test()
+        {
+            Reset();
+            SetInput("Previous message");
+
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, OUTPRF_ORDINAL,
+                new List<ushort> { 0xFFFF });
+
+            AppendWithPrf("First row");
+            AppendWithPrf("Second row");
+
+            Assert.Equal("First rowSecond row",
+                Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString("PRFBUF", true)));
+        }
+
+        [Fact]
+        public void prf_AfterOutprfAndChannelIndependentSetStateStartsNewBuffer_Test()
+        {
+            Reset();
+            SetInput("Previous callback output");
+
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, OUTPRF_ORDINAL,
+                new List<ushort> { 0xFFFF });
+
+            majorbbs.SetState(ushort.MaxValue);
+            AppendWithPrf("New callback output");
+
+            Assert.Equal("New callback output",
+                Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString("PRFBUF", true)));
+        }
+
+        [Theory]
+        [InlineData(PRFMSG_ORDINAL)]
+        [InlineData(PRFMLT_ORDINAL)]
+        public void MessageFormatter_AfterOutprfStartsNewBuffer_Test(int formatterOrdinal)
+        {
+            Reset();
+            SetInput("Previous message");
+            SetMcvMessage("New message");
+
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, OUTPRF_ORDINAL,
+                new List<ushort> { 0xFFFF });
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, (ushort)formatterOrdinal,
+                new List<ushort> { 0 });
+
+            Assert.Equal("New message",
+                Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString("PRFBUF", true)));
         }
 
         private void SetInput(string inputValue)
@@ -61,6 +117,23 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             var prfPointer = mbbsEmuMemoryCore.GetPointer("PRFPTR");
             prfPointer.Offset += (ushort)inputValue.Length;
             mbbsEmuMemoryCore.SetPointer("PRFPTR", prfPointer);
+        }
+
+        private void AppendWithPrf(string inputValue)
+        {
+            var inputPointer = mbbsEmuMemoryCore.AllocateVariable(Guid.NewGuid().ToString(),
+                (ushort)(inputValue.Length + 1), true);
+            mbbsEmuMemoryCore.SetArray(inputPointer, Encoding.ASCII.GetBytes(inputValue));
+
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, PRF_ORDINAL,
+                new List<ushort> { inputPointer.Offset, inputPointer.Segment });
+        }
+
+        private void SetMcvMessage(string message)
+        {
+            var mcvPointer = (ushort)majorbbs.McvPointerDictionary.Allocate(new McvFile("TEST.MCV",
+                new Dictionary<int, byte[]> { { 0, Encoding.ASCII.GetBytes(message) } }));
+            mbbsEmuMemoryCore.SetPointer("CURRENT-MCV", new FarPtr(0xFFFF, mcvPointer));
         }
     }
 }

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -108,6 +108,13 @@ namespace MBBSEmu.HostProcess.ExportedModules
         private int _sprIndex;
 
         /// <summary>
+        ///     True after outprf() sends the current buffer. Repeated outprf() calls
+        ///     resend it, while the next formatting call starts a new message. This
+        ///     state belongs to the same per-module Majorbbs instance as PRFBUF.
+        /// </summary>
+        private bool _prfBufferSent;
+
+        /// <summary>
         ///     Int 21h handler
         /// </summary>
         private readonly Int21h _int21h;
@@ -359,9 +366,10 @@ namespace MBBSEmu.HostProcess.ExportedModules
             //Reset NXTCMD
             Module.Memory.SetPointer("NXTCMD", Module.Memory.GetVariablePointer("INPUT"));
 
-            //Reset PRFPTR
+            //A valid-channel callback begins with an empty formatted-output buffer.
             Module.Memory.SetPointer("PRFPTR", Module.Memory.GetVariablePointer("PRFBUF"));
             Module.Memory.SetZero(Module.Memory.GetVariablePointer("PRFBUF"), 0x4000);
+            _prfBufferSent = false;
 
             //Set FSDSCB Pointer for Current User
             var channelFsdscb = Module.Memory.GetOrAllocateVariablePointer($"FSD-Fsdscb-{ChannelNumber}", FsdscbStruct.Size);
@@ -2106,6 +2114,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
             //If the supplied string has any control characters for formatting, process them
             var formattedMessage = FormatPrintf(output, 2);
 
+            PreparePrfBufferForWrite();
+
             var pointerPosition = Module.Memory.GetPointer("PRFPTR");
             Module.Memory.SetArray(pointerPosition, formattedMessage);
 
@@ -2129,6 +2139,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             //Set prfptr to the base address of prfbuf
             Module.Memory.SetPointer("PRFPTR", Module.Memory.GetVariablePointer("PRFBUF"));
             Module.Memory.SetByte(Module.Memory.GetVariablePointer("PRFBUF"), 0);
+            _prfBufferSent = false;
 
 #if DEBUG
             _logger.Debug($"({Module.ModuleIdentifier}) Reset Output Buffer");
@@ -2136,10 +2147,27 @@ namespace MBBSEmu.HostProcess.ExportedModules
         }
 
         /// <summary>
+        ///     Begin a new message when the previous contents have already been sent.
+        ///     The buffer remains untouched between repeated outprf() calls so one
+        ///     formatted message can still be broadcast to multiple channels.
+        /// </summary>
+        private void PreparePrfBufferForWrite()
+        {
+            if (!_prfBufferSent)
+                return;
+
+            var basePointer = Module.Memory.GetVariablePointer("PRFBUF");
+            Module.Memory.SetPointer("PRFPTR", basePointer);
+            Module.Memory.SetByte(basePointer, 0);
+            _prfBufferSent = false;
+        }
+
+        /// <summary>
         ///     Send prfbuf to a channel
         ///
-        ///     Does NOT clear prfbuf -- that's clrprf()'s job. This allows the same
-        ///     buffered output to be sent to multiple channels via repeated outprf() calls.
+        ///     Does NOT immediately clear prfbuf. This allows the same buffered output
+        ///     to be sent to multiple channels via repeated outprf() calls. The next
+        ///     formatting call starts a new message.
         ///
         ///     Signature: void outprf (unum)
         /// </summary>
@@ -2159,6 +2187,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             if (ChannelDictionary.ContainsKey(userChannel))
                 ChannelDictionary[userChannel].SendToClient(outputBufferProcessed.ToArray());
+
+            _prfBufferSent = true;
 
 #if DEBUG
             _logger.Debug($"({Module.ModuleIdentifier}) Sent {outputBuffer.Length} bytes to Channel {userChannel}");
@@ -2214,6 +2244,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
             }
 
             var formattedMessage = FormatPrintf(outputMessage, 1);
+
+            PreparePrfBufferForWrite();
 
             var currentPrfPositionPointer = Module.Memory.GetPointer(Module.Memory.GetVariablePointer("PRFPTR"));
 
@@ -4098,6 +4130,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
             //If the supplied string has any control characters for formatting, process them
             var formattedMessage = FormatPrintf(output, 1);
 
+            PreparePrfBufferForWrite();
+
             var currentPrfPositionPointer = Module.Memory.GetPointer(Module.Memory.GetVariablePointer("PRFPTR"));
             Module.Memory.SetArray(currentPrfPositionPointer, formattedMessage);
             currentPrfPositionPointer.Offset += (ushort)(formattedMessage.Length - 1); //dont count the null terminator
@@ -4894,8 +4928,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         private ReadOnlySpan<byte> vdatmp => Module.Memory.GetVariablePointer("*VDATMP").Data;
 
         /// <summary>
-        ///     Send prfbuf to a channel & clear
-        ///     Multilingual version of outprf(), for now we just call outprf()
+        ///     Multilingual version of outprf(), for now we just call outprf().
         /// </summary>
         private void outmlt() => outprf();
 
@@ -7429,8 +7462,9 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             Module.Memory.SetZero(basePointer, outputLength);
 
-            //Set prfptr to the base address of prfbuf
+            //injoth() consumes and clears the formatted-output buffer.
             Module.Memory.SetPointer("PRFPTR", Module.Memory.GetVariablePointer("PRFBUF"));
+            _prfBufferSent = false;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- preserve `PRFBUF` and `PRFPTR` across repeated `outprf()` calls so one formatted message can be sent to multiple channels
- record that the current buffer has been sent, then start a fresh message on the next `prf()`, `prfmsg()`, or `prfmlt()` call
- keep the sent-state flag synchronized with existing buffer resets in valid-channel `SetState()`, `clrprf()`, and `injoth()`
- add regression tests for repeated sends, each formatting entry point, and channel-independent callbacks

## Background

PR #686 fixed one half of the MajorBBS formatted-output lifecycle: `outprf()` must leave the current buffer intact because modules can format a message once and call `outprf()` repeatedly to broadcast it to several channels.

The other half is that the first subsequent formatting operation starts a new message. Without that transition, `prf()`, `prfmsg()`, or `prfmlt()` appends new content to the message that was already sent. This can duplicate earlier output and can eventually produce malformed or truncated displays.

Clearing the buffer directly in `outprf()` would break broadcasts. This change instead tracks whether the current buffer has been sent:

1. Formatting calls append normally while the buffer has not been sent.
2. `outprf()` sends the buffer and marks it as sent without changing `PRFBUF` or `PRFPTR`.
3. Additional `outprf()` calls resend the same buffer.
4. The next formatting call resets `PRFPTR` to `PRFBUF`, terminates the old contents, clears the sent flag, and writes the new message.

## State ownership

`_prfBufferSent` is intentionally an instance field on `Majorbbs`:

- `MbbsHost.GetFunctions()` creates exported-module instances using a key containing the module identifier.
- Each loaded `MbbsModule` therefore receives its own `Majorbbs` instance.
- Each `MbbsModule` also owns its own emulated memory core containing its `PRFBUF` and `PRFPTR`.
- Duplicate module identifiers are rejected during configuration.

The flag and the buffer it describes consequently have the same per-module lifetime and cannot leak between modules.

## `SetState()` behavior

This revision retains current master's existing valid-channel `SetState()` behavior: it clears `PRFBUF` and resets `PRFPTR`, and now also clears `_prfBufferSent` to keep the managed state synchronized.

Unlike the original revision of this PR, it does not move that reset ahead of the `ushort.MaxValue` early return. Channel-independent callbacks preserve the module-local lifecycle state. If the previous buffer was sent, their first formatting call starts fresh through the same normal transition. This avoids broadening `SetState()` behavior solely to implement the output lifecycle.

`injoth()` already consumes and clears the formatted-output buffer, so it now explicitly clears `_prfBufferSent` as well.

## Testing

- focused `outprf` lifecycle tests: 6 passed
- complete MBBSEmu test suite: 2,737 passed, 0 failed
- self-contained Linux x64 publish succeeded
- runtime-tested with classic Galactic Empire, ge-next, and ge-arena loaded simultaneously
- all three modules loaded and operated correctly with no cross-module output contamination
- ge-next `SCAN RANGE` displays complete output without duplicated headers or truncation

The full suite was run with `DOTNET_USE_POLLING_FILE_WATCHER=1` because the test host otherwise exceeded its per-user inotify watcher limit. The initial failures from that run were fixture-construction errors caused by the host resource limit; with polling enabled, the suite passed completely.