### PR TITLE
perf(cpu): lookup-table parity flag calculation

### DIFF
--- a/MBBSEmu/Extensions/ByteExtensions.cs
+++ b/MBBSEmu/Extensions/ByteExtensions.cs
@@ -53,16 +53,8 @@ namespace MBBSEmu.Extensions
         /// </summary>
         /// <param name="b"></param>
         /// <returns>1 == Even, 0 == Odd</returns>
-        public static bool Parity(this byte b)
-        {
-            var setBits = 0;
-            for (var i = 0; i <= 7; i++)
-            {
-                if (b.IsBitSet(i))
-                    setBits++;
-            }
-            return setBits % 2 == 0;
-        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool Parity(this byte b) => ParityTable.Table[b];
 
         /// <summary>
         ///     Sign extends 8bit -> 16bit

--- a/MBBSEmu/Extensions/ParityTable.cs
+++ b/MBBSEmu/Extensions/ParityTable.cs
@@ -1,0 +1,27 @@
+namespace MBBSEmu.Extensions
+{
+    /// <summary>
+    ///     Precomputed even-parity lookup for a single byte, matching the x86 PF flag:
+    ///     Table[b] is true if the number of set bits in b is even.
+    /// </summary>
+    internal static class ParityTable
+    {
+        public static readonly bool[] Table = BuildTable();
+
+        private static bool[] BuildTable()
+        {
+            var table = new bool[256];
+            for (var i = 0; i < table.Length; i++)
+            {
+                var setBits = 0;
+                for (var bit = 0; bit <= 7; bit++)
+                {
+                    if ((i & (1 << bit)) != 0)
+                        setBits++;
+                }
+                table[i] = setBits % 2 == 0;
+            }
+            return table;
+        }
+    }
+}

--- a/MBBSEmu/Extensions/UintExtensions.cs
+++ b/MBBSEmu/Extensions/UintExtensions.cs
@@ -56,16 +56,7 @@ namespace MBBSEmu.Extensions
         /// </summary>
         /// <param name="b"></param>
         /// <returns>1 == Even, 0 == Odd</returns>
-        public static bool Parity(this uint b)
-        {
-            var setBits = 0;
-            for (var i = 0; i <= 7; i++)
-            {
-                if (b.IsBitSet(i))
-                    setBits++;
-            }
-
-            return setBits % 2 == 0;
-        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool Parity(this uint b) => ParityTable.Table[(byte)b];
     }
 }

--- a/MBBSEmu/Extensions/UshortExtensions.cs
+++ b/MBBSEmu/Extensions/UshortExtensions.cs
@@ -57,17 +57,8 @@ namespace MBBSEmu.Extensions
         /// </summary>
         /// <param name="b"></param>
         /// <returns>1 == Even, 0 == Odd</returns>
-        public static bool Parity(this ushort b)
-        {
-            var setBits = 0;
-            for (var i = 0; i <= 7; i++)
-            {
-                if (b.IsBitSet(i))
-                    setBits++;
-            }
-
-            return setBits % 2 == 0;
-        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool Parity(this ushort b) => ParityTable.Table[(byte)b];
 
         /// <summary>
         ///     Sign extends 16bit -> 32bit


### PR DESCRIPTION
## Summary
- `Parity()` (byte/ushort/uint extensions) is called on every ALU op that sets flags via `Flags_EvaluateSignZero`, and computed set-bit count with an 8-iteration bit-test loop + modulo.
- Replaced with a single index into a precomputed 256-entry lookup table (`Extensions/ParityTable.cs`), keyed on the low byte — matching existing behavior where x86 parity is always computed on bits 0-7 regardless of operand width.

## Test plan
- [x] `dotnet test` — all 2705 existing tests pass unchanged
- [x] A/B benchmarked with a standalone `Tick()`-driven harness (INC-heavy loop, since INC exercises `Flags_EvaluateSignZero`/parity every iteration), alternating base/variant DLLs to rule out run-order drift: ~30% higher instructions/sec vs. the bit-loop (14.7M -> 19.2M avg across 6 alternating runs each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeMCAxUq7EZSwjgWfeFxyP