### PR TITLE
Fix printf floating-point precision

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/ExportedModuleTestBase.cs
+++ b/MBBSEmu.Tests/ExportedModules/ExportedModuleTestBase.cs
@@ -303,6 +303,15 @@ namespace MBBSEmu.Tests.ExportedModules
                             parameters.Add(BitConverter.ToUInt16(longBytes, 2));
                             break;
                         }
+                    case double @parameterDouble:
+                        {
+                            var doubleBytes = BitConverter.GetBytes(@parameterDouble);
+                            parameters.Add(BitConverter.ToUInt16(doubleBytes, 0));
+                            parameters.Add(BitConverter.ToUInt16(doubleBytes, 2));
+                            parameters.Add(BitConverter.ToUInt16(doubleBytes, 4));
+                            parameters.Add(BitConverter.ToUInt16(doubleBytes, 6));
+                            break;
+                        }
                     case ushort @parameterUInt:
                         parameters.Add(@parameterUInt);
                         break;

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/sprintf_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/sprintf_Tests.cs
@@ -42,6 +42,11 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("%%%%% ", "%%% ", null)] //Escaped & Unescaped %
         [InlineData("%-8s", "gold crowns", "gold crowns")]
         [InlineData("%-8s", "gold    ", "gold")]
+        [InlineData("%f", "12.345600", 12.3456)]
+        [InlineData("%.2f", "12.35", 12.3456)]
+        [InlineData("%.0f", "12", 12.3456)]
+        [InlineData("%8.2f", "   12.35", 12.3456)]
+        [InlineData("%-8.2f", "12.35   ", 12.3456)]
         //Hex conversions (#683): accepted by PRINTF_SPECIFIERS but previously unimplemented
         [InlineData("%x", "ff", (ushort)255)]
         [InlineData("%X", "FF", (ushort)255)]

--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -446,6 +446,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                     }
 
                     //Process Precision
+                    var hasPrecision = IsPrintfPrecision(stringToParse.Slice(i, 1));
                     var stringPrecision = 0;
                     var stringPrecisionValue = string.Empty;
                     while (InSpan(PRINTF_PRECISION, stringToParse.Slice(i, 1)))
@@ -698,8 +699,10 @@ namespace MBBSEmu.HostProcess.ExportedModules
                                     floatValue = Module.Memory.GetArray(Registers.SS, parameterValue, 8).ToArray();
                                 }
 
-                                msFormattedValue.Write(
-                                    Encoding.ASCII.GetBytes(((float)BitConverter.ToDouble(floatValue)).ToString()));
+                                var value = BitConverter.ToDouble(floatValue);
+                                var precision = hasPrecision ? stringPrecision : 6;
+                                msFormattedValue.Write(Encoding.ASCII.GetBytes(
+                                    value.ToString($"F{precision}", CultureInfo.InvariantCulture)));
 
                                 break;
                             }


### PR DESCRIPTION
## Summary
- honor explicit precision for `%f` conversions, including `%.0f` and `%.2f`
- use the standard six decimal places when precision is omitted
- preserve the full `double` value and use culture-invariant formatting
- add formatter tests for precision, width, and left justification

## Testing
- `dotnet test MBBSEmu.Tests/MBBSEmu.Tests.csproj --filter FullyQualifiedName~ExportedModules.Majorbbs.sprintf_Tests --no-restore`
- 40 tests passed
- verified with ge-next after removing its MBBSEmu-specific `%.2f` workaround