### PR TITLE
Fix Telnet negotiation and terminal input handling

### DIFF
--- a/MBBSEmu.Tests/Session/Telnet/IacFilter_Tests.cs
+++ b/MBBSEmu.Tests/Session/Telnet/IacFilter_Tests.cs
@@ -103,6 +103,29 @@ namespace MBBSEmu.Tests.Session.Telnet
                 stream.ToArray());
         }
 
+        [Theory]
+        [InlineData(new byte[] { (byte)'A', 0x0D, 0x0A, (byte)'B' }, new byte[] { (byte)'A', 0x0D, (byte)'B' })]
+        [InlineData(new byte[] { (byte)'A', 0x0D, 0x00, (byte)'B' }, new byte[] { (byte)'A', 0x0D, (byte)'B' })]
+        [InlineData(new byte[] { (byte)'A', 0x0A, (byte)'B' }, new byte[] { (byte)'A', 0x0D, (byte)'B' })]
+        public void NormalizesTerminalInput(byte[] input, byte[] expected)
+        {
+            var (bytes, length) = iacFilter.ProcessIncomingClientData(input, input.Length);
+
+            Assert.Equal(expected, new ReadOnlySpan<byte>(bytes).Slice(0, length).ToArray());
+        }
+
+        [Theory]
+        [InlineData(0x0A)]
+        [InlineData(0x00)]
+        public void NormalizesCarriageReturnSequenceAcrossPackets(byte trailingByte)
+        {
+            var (bytes, length) = iacFilter.ProcessIncomingClientData(new byte[] { (byte)'A', 0x0D }, 2);
+            Assert.Equal(new byte[] { (byte)'A', 0x0D }, new ReadOnlySpan<byte>(bytes).Slice(0, length).ToArray());
+
+            (bytes, length) = iacFilter.ProcessIncomingClientData(new byte[] { trailingByte, (byte)'B' }, 2);
+            Assert.Equal(new byte[] { (byte)'B' }, new ReadOnlySpan<byte>(bytes).Slice(0, length).ToArray());
+        }
+
         private static byte[] Concat(params byte[][] arrays)
         {
             var length = 0;

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -898,7 +898,7 @@ namespace MBBSEmu.HostProcess
             switch (session.CharacterReceived)
             {
                 //Backspace
-                case 127 when session.SessionState == EnumSessionState.InModule:
+                case 127:
                 case 0x8:
                     {
                         if (session.InputBuffer.Length > 0)

--- a/MBBSEmu/Session/Telnet/IacFilter.cs
+++ b/MBBSEmu/Session/Telnet/IacFilter.cs
@@ -32,6 +32,7 @@ namespace MBBSEmu.Session.Telnet
         private ParseState _parseState = ParseState.Normal;
         private EnumIacVerbs _currentVerb;
         private EnumIacOptions _currentSubnegotiationOption;
+        private bool _lastCharacterWasCarriageReturn;
 
         public class IacVerbReceivedEventArgs : EventArgs
         {
@@ -75,7 +76,7 @@ namespace MBBSEmu.Session.Telnet
                     _parseState = ParseState.FoundIAC;
                     break;
                 case ParseState.Normal:
-                    _memoryStream.WriteByte(b);
+                    WriteDataByte(b);
                     break;
                 case ParseState.FoundIAC when b == SB:
                     _parseState = ParseState.SBStart;
@@ -127,6 +128,28 @@ namespace MBBSEmu.Session.Telnet
                     _parseState = ParseState.SBValue;
                     break;
             }
+        }
+
+        /// <summary>
+        ///     Normalizes common Telnet terminal input to the bytes MajorBBS expects.
+        /// </summary>
+        private void WriteDataByte(byte b)
+        {
+            if (_lastCharacterWasCarriageReturn)
+            {
+                _lastCharacterWasCarriageReturn = false;
+
+                // CR LF and CR NUL each represent one carriage return in NVT mode.
+                if (b == 0x0A || b == 0x00)
+                    return;
+            }
+
+            // Some clients send LF alone for Enter.
+            if (b == 0x0A)
+                b = 0x0D;
+
+            _memoryStream.WriteByte(b);
+            _lastCharacterWasCarriageReturn = b == 0x0D;
         }
     }
 }

--- a/MBBSEmu/Session/Telnet/TelnetSession.cs
+++ b/MBBSEmu/Session/Telnet/TelnetSession.cs
@@ -16,8 +16,6 @@ namespace MBBSEmu.Session.Telnet
     /// </summary>
     public class TelnetSession : SocketSession
     {
-        private int _iacPhase;
-
         private static readonly byte[] IAC_NOP = { 0xFF, 0xF1 };
 
         private readonly bool _heartbeat;
@@ -43,7 +41,7 @@ namespace MBBSEmu.Session.Telnet
                 {EnumIacOptions.BinaryTransmission, new TelnetOptionsValue { Local = true, Remote = true}},
                 {EnumIacOptions.Echo, new TelnetOptionsValue { Local = true, Remote = false}},
                 {EnumIacOptions.SuppressGoAhead, new TelnetOptionsValue { Local = true, Remote = true}},
-                {EnumIacOptions.NegotiateAboutWindowSize, new TelnetOptionsValue { Local = true, Remote = true }},
+                {EnumIacOptions.NegotiateAboutWindowSize, new TelnetOptionsValue { Local = false, Remote = true }},
             };
 
         private readonly IacFilter _iacFilter;
@@ -116,12 +114,10 @@ namespace MBBSEmu.Session.Telnet
             base.Send(msOutputBuffer.ToArray());
         }
 
-        protected override void PreSend()
+        public override void Start()
         {
-            if (SessionTimer.ElapsedMilliseconds >= 500 && _iacPhase == 0)
-            {
-                TriggerIACNegotiation();
-            }
+            TriggerIACNegotiation();
+            base.Start();
         }
 
         protected override (byte[], int) ProcessIncomingClientData(byte[] clientData, int bytesReceived)
@@ -134,8 +130,9 @@ namespace MBBSEmu.Session.Telnet
         /// </summary>
         private void TriggerIACNegotiation()
         {
-            _iacPhase = 1;
-            base.Send(new IacResponse(EnumIacVerbs.DO, EnumIacOptions.BinaryTransmission).ToArray());
+            var responses = new HashSet<IacResponse>();
+            AddInitialNegotiations(responses);
+            SendIacResponses(responses);
         }
 
         private void AddInitialNegotiations(HashSet<IacResponse> responses)
@@ -155,32 +152,39 @@ namespace MBBSEmu.Session.Telnet
 
             if (_localOptions.TryGetValue(args.Option, out var localOptionsValue))
             {
-                // we support this, and we're hard coded, so tell client to back off and listen to
-                // us
-                iacResponses.Add(new IacResponse(localOptionsValue.GetLocalStatusVerb(), args.Option));
-                if (args.Verb == EnumIacVerbs.WILL || args.Verb == EnumIacVerbs.WONT)
+                switch (args.Verb)
                 {
-                    iacResponses.Add(new IacResponse(localOptionsValue.GetRemoteCommandVerb(), args.Option));
+                    case EnumIacVerbs.DO:
+                        iacResponses.Add(new IacResponse(localOptionsValue.GetLocalStatusVerb(), args.Option));
+                        break;
+                    case EnumIacVerbs.DONT:
+                        iacResponses.Add(new IacResponse(EnumIacVerbs.WONT, args.Option));
+                        break;
+                    case EnumIacVerbs.WILL:
+                        iacResponses.Add(new IacResponse(localOptionsValue.GetRemoteCommandVerb(), args.Option));
+                        break;
+                    case EnumIacVerbs.WONT:
+                        iacResponses.Add(new IacResponse(EnumIacVerbs.DONT, args.Option));
+                        break;
                 }
             }
             else
             {
-                // not supported, just return that we WONT do this
-                iacResponses.Add(new IacResponse(EnumIacVerbs.WONT, args.Option));
+                // Reject the action on the side requested by the client.
+                iacResponses.Add(new IacResponse(
+                    args.Verb == EnumIacVerbs.DO || args.Verb == EnumIacVerbs.DONT
+                        ? EnumIacVerbs.WONT
+                        : EnumIacVerbs.DONT,
+                    args.Option));
             }
 
-            //In the 1st phase of IAC negotiation, ensure the required items are being negotiated
-            if (_iacPhase == 0)
-            {
-                AddInitialNegotiations(iacResponses);
-            }
+            SendIacResponses(iacResponses);
+        }
 
-            _iacPhase++;
-
+        private void SendIacResponses(HashSet<IacResponse> iacResponses)
+        {
             if (iacResponses.Count == 0)
-            {
                 return;
-            }
 
             using var msIacToSend = new MemoryStream(128);
             foreach (var resp in iacResponses.Where(resp => _iacSentResponses.Add(resp)))
@@ -190,9 +194,7 @@ namespace MBBSEmu.Session.Telnet
             }
 
             if (msIacToSend.Length > 0)
-            {
                 base.Send(msIacToSend.ToArray());
-            }
         }
 
         private void OnIacSubnegotiationReceived(object sender, IacFilter.IacSubnegotiationEventArgs args)


### PR DESCRIPTION
## Summary
- start Telnet option negotiation before accepting client input instead of delaying it until output processing
- respond to Telnet WILL/WONT and DO/DONT negotiations in the correct direction, including requesting rather than offering NAWS
- normalize CR LF, CR NUL, and lone LF input to the carriage return expected by MajorBBS
- accept DEL as Backspace in every session state, fixing login editing through both Telnet and `-CONSOLE`

`Telnet.ConvertCP437ToUTF8` remains optional and unchanged.

## Testing
- focused Telnet and local-console tests: 16 passed
- verified login, Enter, and Backspace with `telnet localhost 2121`
- verified Backspace during login with `-CONSOLE`
- verified normal input after entering a module