### PR TITLE
Fix DINSBTV insert status handling

### DIFF
--- a/MBBSEmu.Tests/Btrieve/BtrieveFileProcessor_Tests.cs
+++ b/MBBSEmu.Tests/Btrieve/BtrieveFileProcessor_Tests.cs
@@ -167,6 +167,22 @@ namespace MBBSEmu.Tests.Btrieve
         }
 
         [Fact]
+        public void InsertWithStatus_ReturnsNativeInsertStatus()
+        {
+            using var processor = OpenFromDisk();
+
+            var record = new MBBSEmuRecordStruct
+            {
+                Key0 = "Paladine",
+                Key1 = 31337,
+                Key2 = "Status test"
+            };
+
+            processor.InsertWithStatus(record.Data).Should().Be(BtrieveError.Success);
+            processor.InsertWithStatus(record.Data).Should().Be(BtrieveError.DuplicateKeyValue);
+        }
+
+        [Fact]
         public void Update_ExistingRecord_PersistsChange()
         {
             using var processor = OpenFromDisk();

--- a/MBBSEmu/Btrieve/BtrieveFileProcessor.cs
+++ b/MBBSEmu/Btrieve/BtrieveFileProcessor.cs
@@ -420,14 +420,21 @@ namespace MBBSEmu.Btrieve
         /// <return>Position of the newly inserted item, or 0 on failure</return>
         public uint Insert(byte[] record)
         {
-            int dwDataBufferLength = record.Length;
-            if (Wbtrv32.managedBtrcall((int)EnumBtrieveOperationCodes.Insert, unmanagedPosBlock, record,
-                                       ref dwDataBufferLength, null, 0xFF) != 0)
-            {
+            if (InsertWithStatus(record) != BtrieveError.Success)
                 return 0;
-            }
 
             return Position;
+        }
+
+        /// <summary>
+        ///     Inserts a new Btrieve Record and returns the native Btrieve status.
+        /// </summary>
+        public BtrieveError InsertWithStatus(byte[] record)
+        {
+            int dwDataBufferLength = record.Length;
+            return (BtrieveError)Wbtrv32.managedBtrcall((int)EnumBtrieveOperationCodes.Insert,
+                                                        unmanagedPosBlock, record, ref dwDataBufferLength,
+                                                        null, 0xFF);
         }
 
         /// <summary>

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -2769,8 +2769,9 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// </summary>
         private void insbtv()
         {
-            if (!insertBtv(LogLevel.Critical))
-                throw new SystemException("Failed to insert database record");
+            var result = insertBtv();
+            if (result != BtrieveError.Success)
+                throw new SystemException($"Failed to insert database record: {result}");
         }
 
         /// <summary>
@@ -2781,10 +2782,15 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// <returns></returns>
         private void dinsbtv()
         {
-            Registers.AX = insertBtv(LogLevel.Debug) ? (ushort)1 : (ushort)0;
+            var result = insertBtv();
+            if (result != BtrieveError.Success &&
+                result != BtrieveError.DuplicateKeyValue)
+                throw new SystemException($"Failed to insert database record: {result}");
+
+            Registers.AX = result == BtrieveError.Success ? (ushort)1 : (ushort)0;
         }
 
-        private bool insertBtv(LogLevel logLevel)
+        private BtrieveError insertBtv()
         {
             var btrieveRecordPointer = GetParameterPointer(0);
 
@@ -2792,7 +2798,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             var dataToWrite = Module.Memory.GetArray(btrieveRecordPointer, (ushort)currentBtrieveFile.RecordLength);
 
-            return currentBtrieveFile.Insert(dataToWrite.ToArray()) != 0;
+            return currentBtrieveFile.InsertWithStatus(dataToWrite.ToArray());
         }
 
 


### PR DESCRIPTION
## Summary

- expose the native Btrieve insert status without changing the existing position-returning `Insert` API
- make `DINSBTV` return 1 for success and 0 only for duplicate-key status
- preserve MajorBBS's fatal behavior for other insert errors

## Background

`DINSBTV` currently determines success from `BtrieveFileProcessor.Insert()`'s returned record position. A native insert can succeed while the processor's current position is still zero, causing callers to receive a false failure even though the record was written.

MajorBBS checks the raw Btrieve status instead: status 0 is success, status 5 is a duplicate, and other errors are fatal.

## Testing

- `dotnet test MBBSEmu.Tests/MBBSEmu.Tests.csproj --configuration Release --filter FullyQualifiedName~BtrieveFileProcessor_Tests --no-restore`
- verified with ge-next under MBBSEmu that user, sector/planet, and ship inserts no longer report false failures
