### PR TITLE
Implement RSMODES cleanup state

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/rsmodes_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/rsmodes_Tests.cs
@@ -1,0 +1,26 @@
+using MBBSEmu.Memory;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class rsmodes_Tests : ExportedModuleTestBase
+    {
+        private const ushort RSMODES_ORDINAL = 504;
+
+        [Fact]
+        public void RSMODES_ExportsInitializedPerChannelArray()
+        {
+            var pointer = new FarPtr(majorbbs.Invoke(RSMODES_ORDINAL));
+            var expectedPointer = mbbsEmuMemoryCore.GetVariablePointer("RSMODES");
+
+            Assert.Equal(expectedPointer, pointer);
+            Assert.Equal(Majorbbs.NORMRS, mbbsEmuMemoryCore.GetWord(pointer));
+            Assert.Equal(Majorbbs.NORMRS, mbbsEmuMemoryCore.GetWord(pointer + sizeof(ushort)));
+
+            majorbbs.SetResetModes(Majorbbs.NANSRS);
+
+            Assert.Equal(Majorbbs.NANSRS, mbbsEmuMemoryCore.GetWord(pointer));
+            Assert.Equal(Majorbbs.NANSRS, mbbsEmuMemoryCore.GetWord(pointer + sizeof(ushort)));
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/rsmodes_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/rsmodes_Tests.cs
@@ -1,5 +1,6 @@
 using MBBSEmu.Memory;
 using Xunit;
+using MajorbbsModule = MBBSEmu.HostProcess.ExportedModules.Majorbbs;
 
 namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 {
@@ -10,17 +11,18 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [Fact]
         public void RSMODES_ExportsInitializedPerChannelArray()
         {
-            var pointer = new FarPtr(majorbbs.Invoke(RSMODES_ORDINAL));
-            var expectedPointer = mbbsEmuMemoryCore.GetVariablePointer("RSMODES");
+            var exportedPointer = new FarPtr(majorbbs.Invoke(RSMODES_ORDINAL));
+            var pointer = mbbsEmuMemoryCore.GetPointer("*RSMODES");
 
-            Assert.Equal(expectedPointer, pointer);
-            Assert.Equal(Majorbbs.NORMRS, mbbsEmuMemoryCore.GetWord(pointer));
-            Assert.Equal(Majorbbs.NORMRS, mbbsEmuMemoryCore.GetWord(pointer + sizeof(ushort)));
+            Assert.Equal(mbbsEmuMemoryCore.GetVariablePointer("*RSMODES"), exportedPointer);
+            Assert.Equal(mbbsEmuMemoryCore.GetVariablePointer("RSMODES"), pointer);
+            Assert.Equal(MajorbbsModule.NORMRS, mbbsEmuMemoryCore.GetWord(pointer));
+            Assert.Equal(MajorbbsModule.NORMRS, mbbsEmuMemoryCore.GetWord(pointer + sizeof(ushort)));
 
-            majorbbs.SetResetModes(Majorbbs.NANSRS);
+            majorbbs.SetResetModes(MajorbbsModule.NANSRS);
 
-            Assert.Equal(Majorbbs.NANSRS, mbbsEmuMemoryCore.GetWord(pointer));
-            Assert.Equal(Majorbbs.NANSRS, mbbsEmuMemoryCore.GetWord(pointer + sizeof(ushort)));
+            Assert.Equal(MajorbbsModule.NANSRS, mbbsEmuMemoryCore.GetWord(pointer));
+            Assert.Equal(MajorbbsModule.NANSRS, mbbsEmuMemoryCore.GetWord(pointer + sizeof(ushort)));
         }
     }
 }

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -89,6 +89,9 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// <returns></returns>
         public const ushort Segment = 0xFFFF;
 
+        internal const ushort NORMRS = 0;
+        internal const ushort NANSRS = 'N';
+
         /// <summary>
         ///     Repository with Account Key Information
         /// </summary>
@@ -153,6 +156,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             Module.Memory.AllocateVariable("USER", (ushort)(User.Size * _numberOfChannels), true);
             Module.Memory.AllocateVariable("*USRPTR", 0x4); //pointer to the current USER record
             Module.Memory.AllocateVariable("STATUS", 0x2); //ushort Status
+            Module.Memory.AllocateVariable("RSMODES", (ushort)(sizeof(ushort) * _numberOfChannels), true);
             Module.Memory.AllocateVariable("CHANNEL", 0x1FE); //255 channels * 2 bytes
             Module.Memory.AllocateVariable("MARGC", sizeof(ushort));
             Module.Memory.AllocateVariable("MARGN", 0x200); //max 128 pointers * 4 bytes each
@@ -462,6 +466,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
                     return nterms;
                 case 625:
                     return user;
+                case 504:
+                    return rsmodes;
                 case 637:
                     return vdaptr;
                 case 401:
@@ -3180,6 +3186,21 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// </summary>
         /// <returns></returns>
         private ReadOnlySpan<byte> user => Module.Memory.GetVariablePointer("*USER").Data;
+
+        /// <summary>
+        ///     Pointer to the per-channel reset mode array.
+        ///
+        ///     Signature: int *rsmodes;
+        /// </summary>
+        private ReadOnlySpan<byte> rsmodes => Module.Memory.GetVariablePointer("*RSMODES").Data;
+
+        internal void SetResetModes(ushort resetMode)
+        {
+            var resetModesPointer = Module.Memory.GetVariablePointer("RSMODES");
+
+            for (var channel = 0; channel <= _configuration.BBSChannels; channel++)
+                Module.Memory.SetWord(resetModesPointer + (channel * sizeof(ushort)), resetMode);
+        }
 
 
         /// <summary>

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -100,6 +100,11 @@ namespace MBBSEmu.HostProcess
         private readonly Timer _cleanupTimer;
 
         /// <summary>
+        ///     Timer that marks the beginning of the nightly cleanup grace period
+        /// </summary>
+        private readonly Timer _cleanupStartTimer;
+
+        /// <summary>
         ///     Timer that triggers when nightly cleanup warning messages should start
         /// </summary>
         private Timer _cleanupWarningTimer;
@@ -131,6 +136,7 @@ namespace MBBSEmu.HostProcess
         ///     Flag that controls whether the main loop will perform a nightly cleanup
         /// </summary>
         private bool _performCleanup = false;
+        private bool _prepareCleanup = false;
         private EventWaitHandle _cleanupRestartEvent = null;
 
         /// <summary>
@@ -192,7 +198,12 @@ namespace MBBSEmu.HostProcess
 
             //Setup Cleanup Restart Event
             _cleanupTime = _configuration.CleanupTime;
-            _cleanupTimer = new Timer(_ => _performCleanup = true, null, NowUntil(_cleanupTime + _cleanupGracePeriod), TimeSpan.FromDays(1));
+            var cleanupStartDue = NowUntil(_cleanupTime);
+            var cleanupDue = NowUntil(_cleanupTime + _cleanupGracePeriod);
+            if (cleanupDue < cleanupStartDue)
+                _prepareCleanup = true;
+            _cleanupStartTimer = new Timer(_ => _prepareCleanup = true, null, cleanupStartDue, TimeSpan.FromDays(1));
+            _cleanupTimer = new Timer(_ => _performCleanup = true, null, cleanupDue, TimeSpan.FromDays(1));
             _cleanupWarningTimer = SetupCleanupWarningTimer();
 
             if (_configuration.TimerHertz > 0)
@@ -272,6 +283,7 @@ namespace MBBSEmu.HostProcess
         public void Stop()
         {
             _isRunning = false;
+            _cleanupStartTimer?.Dispose();
             _cleanupTimer?.Dispose();
             _cleanupWarningTimer?.Dispose();
             _tickTimer?.Dispose();
@@ -1458,6 +1470,13 @@ namespace MBBSEmu.HostProcess
         /// </summary>
         private void ProcessNightlyCleanup()
         {
+            if (_prepareCleanup)
+            {
+                Logger.Info("Beginning nightly cleanup grace period.");
+                _prepareCleanup = false;
+                SetCleanupResetModes();
+            }
+
             if (_performCleanup)
             {
                 Logger.Info($"Beginning nightly cleanup process.");
@@ -1487,6 +1506,9 @@ namespace MBBSEmu.HostProcess
             foreach (var localConsoleSession in _channelDictionary.Values.OfType<LocalConsoleSession>())
                 localConsoleSession.StopHostOnStop = false;
 
+            // MajorBBS sets the modes again in hupall() before invoking each module's HUPROU.
+            SetCleanupResetModes();
+
             // removes all sessions before module cleanup
             RemoveSessions(session => true);
 
@@ -1509,6 +1531,16 @@ namespace MBBSEmu.HostProcess
             Logger.Info("NIGHTLY CLEANUP COMPLETE -- RESTARTING HOST");
 
             Start(moduleConfigurations);
+        }
+
+        private void SetCleanupResetModes()
+        {
+            foreach (var module in _modules.Values)
+            {
+                if (module.ExportedModuleDictionary.TryGetValue(Majorbbs.Segment, out var exportedModule) &&
+                    exportedModule is Majorbbs majorbbs)
+                    majorbbs.SetResetModes(Majorbbs.NANSRS);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

- export the MajorBBS `rsmodes` per-channel reset-mode array at ordinal 504
- initialize each channel to `NORMRS`
- set all channels to `NANSRS` when the nightly cleanup grace period begins
- set the modes again immediately before cleanup disconnects users

## Background

MajorBBS sets `rsmodes[]` to its configured non-normal reset mode when the cleanup grace period begins, then sets it again in `hupall()` before invoking module hangup routines. Modules use this to distinguish an ordinary lost-carrier hangup from a system cleanup.

Without `RSMODES`, modules can treat cleanup as an ordinary disconnect and apply gameplay consequences intended only for a real hangup.

Timer callbacks only signal the host worker loop; module memory is updated from the worker thread. All configured channels are updated, including vacant channels that may be assigned during the grace period.

## Testing

- focused `rsmodes_Tests` and existing `NightlyCleanup_Tests` pass
- verified `rsmodes[0]` reports `NORMRS` during normal operation
- verified it changes to `NANSRS` at the configured cleanup time, before warning messages begin
- verified a combat-locked ge-next ship survives forced nightly cleanup
