### PR TITLE
Return local console to login after cleanup

### DIFF
--- a/MBBSEmu.Tests/Session/SessionBase_Tests.cs
+++ b/MBBSEmu.Tests/Session/SessionBase_Tests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
+using MBBSEmu.HostProcess.Enums;
 using MBBSEmu.Session;
+using MBBSEmu.Session.Enums;
 using System;
 using System.Text;
 using Xunit;
@@ -114,6 +116,42 @@ namespace MBBSEmu.Tests.Session
             // should be no lines left to read
             Assert.Throws<TimeoutException>(() => testSession.GetLine(TimeSpan.FromMilliseconds(100)));
 
+        }
+
+        [Fact]
+        public void ResetForLogin_ClearsPriorSessionState()
+        {
+            var session = new TestSession(null, null)
+            {
+                Password = "password",
+                Email = "sysop@example.com",
+                DataToProcess = true,
+                InputLockout = true,
+                EchoSecureEnabled = true,
+                BinaryOutputMode = true
+            };
+
+            session.Status.Enqueue(EnumUserStatus.CR_TERMINATED_STRING_AVAILABLE);
+            session.DataFromClient.Add((byte)'x');
+            session.DataToClient.Add(Encoding.ASCII.GetBytes("pending"));
+            session.InputBuffer.WriteByte((byte)'x');
+            session.EchoBuffer.WriteByte((byte)'x');
+
+            session.ResetForLogin();
+
+            Assert.Equal(EnumSessionState.Unauthenticated, session.SessionState);
+            Assert.Empty(session.Username);
+            Assert.Empty(session.Password);
+            Assert.Empty(session.Email);
+            Assert.Empty(session.Status);
+            Assert.Empty(session.DataFromClient);
+            Assert.Empty(session.DataToClient);
+            Assert.Equal(0, session.InputBuffer.Length);
+            Assert.Equal(0, session.EchoBuffer.Length);
+            Assert.False(session.DataToProcess);
+            Assert.False(session.InputLockout);
+            Assert.False(session.EchoSecureEnabled);
+            Assert.False(session.BinaryOutputMode);
         }
     }
 }

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -1096,6 +1096,11 @@ namespace MBBSEmu.HostProcess
         /// <returns></returns>
         public bool RemoveSession(ushort channel)
         {
+            return RemoveSession(channel, true);
+        }
+
+        private bool RemoveSession(ushort channel, bool stopSession)
+        {
             if (!_channelDictionary.ContainsKey(channel))
             {
                 return false;
@@ -1106,7 +1111,8 @@ namespace MBBSEmu.HostProcess
             CallModuleRoutine("huprou", preRunCallback: null, channel);
 
             var session = _channelDictionary[channel];
-            session.Stop();
+            if (stopSession)
+                session.Stop();
             session.SessionState = EnumSessionState.Disconnected;
 
             _channelDictionary.Remove(channel);
@@ -1480,12 +1486,15 @@ namespace MBBSEmu.HostProcess
         {
             Logger.Info("PERFORMING NIGHTLY CLEANUP");
 
+            var localConsoleSessions = _channelDictionary.Values.OfType<LocalConsoleSession>().ToList();
+
             // Notify Users of Nightly Cleanup
             foreach (var c in _channelDictionary)
                 _channelDictionary[c.Value.Channel].SendToClient($"|RESET|\r\n|B||RED|Nightly Cleanup Running -- Please log back on shortly|RESET|\r\n".EncodeToANSIArray());
 
-            foreach (var localConsoleSession in _channelDictionary.Values.OfType<LocalConsoleSession>())
-                localConsoleSession.StopHostOnStop = false;
+            // Keep the local console's transport threads alive so it can return to login.
+            foreach (var localConsoleSession in localConsoleSessions)
+                RemoveSession(localConsoleSession.Channel, false);
 
             // removes all sessions before module cleanup
             RemoveSessions(session => true);
@@ -1509,6 +1518,12 @@ namespace MBBSEmu.HostProcess
             Logger.Info("NIGHTLY CLEANUP COMPLETE -- RESTARTING HOST");
 
             Start(moduleConfigurations);
+
+            foreach (var localConsoleSession in localConsoleSessions)
+            {
+                localConsoleSession.ResetForLogin();
+                AddSession(localConsoleSession);
+            }
         }
 
         /// <summary>

--- a/MBBSEmu/Session/LocalConsole/LocalConsoleSession.cs
+++ b/MBBSEmu/Session/LocalConsole/LocalConsoleSession.cs
@@ -24,8 +24,6 @@ namespace MBBSEmu.Session.LocalConsole
         private readonly Thread _consoleOutputThread;
         private bool _consoleInputThreadIsRunning;
         private readonly bool _processClientData;
-        public bool StopHostOnStop { get; set; } = true;
-
         public LocalConsoleSession(IMessageLogger logger, string sessionId, IMbbsHost host, ITextVariableService textVariableService, bool processClientData = true, bool disableLogging = true) : base(host, sessionId, EnumSessionState.Unauthenticated, textVariableService)
         {
             _logger = logger;
@@ -123,8 +121,7 @@ namespace MBBSEmu.Session.LocalConsole
 
             _consoleInputThreadIsRunning = false;
             _timer.Dispose();
-            if (StopHostOnStop)
-                _host?.Stop();
+            _host?.Stop();
 
             Console.Clear();
             // the thread is stuck in ReadKey, the user needs to free that thread to end the

--- a/MBBSEmu/Session/SessionBase.cs
+++ b/MBBSEmu/Session/SessionBase.cs
@@ -342,6 +342,50 @@ namespace MBBSEmu.Session
 
         public abstract void Stop();
 
+        /// <summary>
+        ///     Resets a connected session so it can begin a new login without replacing its
+        ///     underlying transport.
+        /// </summary>
+        public void ResetForLogin()
+        {
+            UsrPtr = new User();
+            UsrAcc = new UserAccount();
+            ExtUsrAcc = new ExtUser();
+            CurrentModule = null;
+            Status = new Queue<EnumUserStatus>();
+            SessionTimer.Reset();
+
+            while (DataToClient.TryTake(out _)) { }
+            while (DataFromClient.TryTake(out _)) { }
+
+            EchoBuffer.SetLength(0);
+            InputBuffer.SetLength(0);
+            InputCommand = new byte[] { 0x0 };
+            CharacterReceived = 0;
+            CharacterProcessed = 0;
+            CharacterInterceptor = default;
+            PollingRoutine = default;
+            PromptCharacter = 0;
+            DataToProcess = false;
+            TransparentMode = false;
+            Monitored = false;
+            Monitored2 = false;
+            Password = string.Empty;
+            Email = string.Empty;
+            OutputEnabled = true;
+            OutputEmptyStatus = false;
+            InputLockout = false;
+            EchoEmptyInvoke = false;
+            EchoEmptyInvokeEnabled = false;
+            EchoSecureEnabled = false;
+            VDA = new byte[Majorbbs.VOLATILE_DATA_SIZE];
+            TerminalColumns = DEFAULT_TERMINAL_COLUMNS;
+            WordWrapWidth = 0;
+            BinaryOutputMode = false;
+            ResetScreenPauseState();
+            SessionState = EnumSessionState.Unauthenticated;
+        }
+
         protected SessionBase(IMbbsHost mbbsHost, string sessionId, EnumSessionState startingSessionState, ITextVariableService textVariableService)
         {
             _mbbsHost = mbbsHost;


### PR DESCRIPTION
## Summary

- preserve local console transport threads during nightly cleanup
- reset all per-login session state after modules restart
- return the local console to the login screen instead of leaving it disconnected
- remove the cleanup-specific `StopHostOnStop` state

Telnet sessions retain their existing cleanup behavior. Only `LocalConsoleSession` instances are detached without stopping their transport, reset, and added back after the host restarts.

## Testing

- 11 focused `SessionBase_Tests` pass
- tested cleanup with ge-next, ge-arena, and classic Galactic Empire loaded
- confirmed telnet users can reconnect normally
- confirmed `-CONSOLE` returns to login and accepts a new login after cleanup

