### PR TITLE
fix(benchmark): eliminate instruction counter race in CPU benchmark

### DIFF
--- a/MBBSEmu.CPU.Benchmark/Program.cs
+++ b/MBBSEmu.CPU.Benchmark/Program.cs
@@ -75,11 +75,13 @@ namespace MBBSEmu.CPU.Benchmark
 
         private void MonitorThread()
         {
+            var lastCount = 0L;
             while (_isRunning)
             {
                 new AutoResetEvent(false).WaitOne(1000);
-                Console.WriteLine($"Instructions Per Second: {mbbsEmuCpuCore.InstructionCounter}");
-                mbbsEmuCpuCore.InstructionCounter = 0;
+                var currentCount = mbbsEmuCpuCore.InstructionCounter;
+                Console.WriteLine($"Instructions Per Second: {currentCount - lastCount}");
+                lastCount = currentCount;
             }
         }
 


### PR DESCRIPTION
## Summary
- `InstructionCounter` is incremented (non-atomically) by the run thread on every CPU tick.
- The monitor thread read it and then reset it to `0` once a second with no synchronization, so a reset could race with an in-flight `InstructionCounter++` and get clobbered, letting the count silently carry into the next interval — this is why some printed rates looked roughly double (or more) the real instructions/sec.
- Fix: the monitor thread now only reads the counter and reports the delta from its last sample, instead of ever writing to it. This makes it single-writer (run thread) / single-reader (monitor thread), so there's no shared mutation to race on.

## Test plan
- [x] `dotnet build`
- [ ] Manually run `MBBSEmu.CPU.Benchmark` for a few minutes and confirm reported instructions/sec no longer shows anomalous doubled spikes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116QoLSM14ebPfyqZF9aobS