### PR TITLE
Preserve non-ASCII bytes in strncpy

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/strncpy_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/strncpy_Tests.cs
@@ -45,5 +45,31 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             Assert.Equal(destinationStringPointer.Segment, mbbsEmuCpuRegisters.DX);
             Assert.Equal(destinationStringPointer.Offset, mbbsEmuCpuRegisters.AX);
         }
+
+        [Fact]
+        public void strncpy_CopiesNonAsciiBytesVerbatim()
+        {
+            Reset();
+
+            var destinationPointer = mbbsEmuMemoryCore.AllocateVariable("DST", 2);
+            mbbsEmuMemoryCore.SetArray(destinationPointer, new byte[] { 0, 0 });
+
+            var sourcePointer = mbbsEmuMemoryCore.AllocateVariable("SRC", 2);
+            mbbsEmuMemoryCore.SetArray(sourcePointer, new byte[] { 0xAD, 0 });
+
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, STRNCPY_ORDINAL,
+                new List<ushort>
+                {
+                    destinationPointer.Offset,
+                    destinationPointer.Segment,
+                    sourcePointer.Offset,
+                    sourcePointer.Segment,
+                    1
+                });
+
+            Assert.Equal(0xAD, mbbsEmuMemoryCore.GetByte(destinationPointer));
+            Assert.Equal(destinationPointer.Segment, mbbsEmuCpuRegisters.DX);
+            Assert.Equal(destinationPointer.Offset, mbbsEmuCpuRegisters.AX);
+        }
     }
 }

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -3039,7 +3039,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         private void strncpy()
         {
             var destinationPointer = GetParameterPointer(0);
-            var source = GetParameterString(2);
+            var source = GetParameterStringSpan(2);
             var numberOfBytesToCopy = GetParameter(4);
 
             Registers.SetPointer(destinationPointer);
@@ -3055,7 +3055,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                     break;
                 }
 
-                Module.Memory.SetByte(destinationPointer, (byte)source[i]);
+                Module.Memory.SetByte(destinationPointer, source[i]);
             }
         }
 


### PR DESCRIPTION
## Summary

- copy `strncpy` source data directly from emulated memory rather than decoding it as an ASCII .NET string
- preserve non-ASCII byte values such as `0xAD`
- add a regression test covering a non-ASCII source byte and the returned destination pointer

## Background

MajorBBS `strncpy` operates on raw bytes. MBBSEmu previously read the source through `GetParameterString()`, which decodes it with `Encoding.ASCII`. Bytes outside ASCII are replaced with `?` (`0x3F`) before being written to the destination.

Classic Galactic Empire exposes this difference. Its security subsystem uses a private record key beginning with byte `0xAD` and copies that byte with `strncpy` when filtering the record from the roster. Under MBBSEmu, the copied byte became `0x3F`, so the comparison failed and the security record appeared as a player. Copying from `GetParameterStringSpan()` preserves MajorBBS behavior and keeps the record out of the roster.

## Testing

- focused `strncpy_Tests`: 5 passed
- verified with classic Galactic Empire under MBBSEmu that the security record no longer appears in the roster
