### PR TITLE
Update the Wbtrv32 resolver to ignore dll since that only works on Windows

### DIFF
--- a/MBBSEmu/Btrieve/Wbtrv32.cs
+++ b/MBBSEmu/Btrieve/Wbtrv32.cs
@@ -24,7 +24,7 @@ namespace MBBSEmu.Btrieve
                     RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "wbtrv32.dylib" :
                     "wbtrv32.so";
 
-            if (!string.Equals(libraryName, "wbtrv32.dll", StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(libraryName, "wbtrv32", StringComparison.OrdinalIgnoreCase))
                 return IntPtr.Zero;
 
             nint handle;


### PR DESCRIPTION
## Summary
- Wbtrv32 resolver matched against the literal `wbtrv32.dll` name, which only makes sense on Windows; it now matches the platform-agnostic base name `wbtrv32` so the correct native library (`.dylib`/`.so`/`.dll`) resolves on macOS and Linux too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016756h9B7Tjky7acqWxuMaK