### PR TITLE
Bump MBBSEmu.wbtrv32 package reference to 1.0.2

### DIFF
--- a/MBBSDatabase/MBBSDatabase.csproj
+++ b/MBBSDatabase/MBBSDatabase.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MBBSEmu.wbtrv32" Version="1.0.1" />
+    <PackageReference Include="MBBSEmu.wbtrv32" Version="1.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MBBSEmu.CPU.Benchmark/MBBSEmu.CPU.Benchmark.csproj
+++ b/MBBSEmu.CPU.Benchmark/MBBSEmu.CPU.Benchmark.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MBBSEmu.wbtrv32" Version="1.0.1" />
+    <PackageReference Include="MBBSEmu.wbtrv32" Version="1.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MBBSEmu.Tests/MBBSEmu.Tests.csproj
+++ b/MBBSEmu.Tests/MBBSEmu.Tests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="Iced" Version="1.10.0" />
-    <PackageReference Include="MBBSEmu.wbtrv32" Version="1.0.1" />
+    <PackageReference Include="MBBSEmu.wbtrv32" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/MBBSEmu/MBBSEmu.csproj
+++ b/MBBSEmu/MBBSEmu.csproj
@@ -74,7 +74,7 @@
 	<ItemGroup>
 		<PackageReference Include="Dapper" Version="2.1.35" />
 		<PackageReference Include="Iced" Version="1.10.0" />
-		<PackageReference Include="MBBSEmu.wbtrv32" Version="1.0.1" />
+		<PackageReference Include="MBBSEmu.wbtrv32" Version="1.0.2" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.0" />


### PR DESCRIPTION
## Summary
- Bump the `MBBSEmu.wbtrv32` NuGet package reference from 1.0.1 to 1.0.2 across all four projects that depend on it (MBBSDatabase, MBBSEmu, MBBSEmu.CPU.Benchmark, MBBSEmu.Tests)

## Test plan
- [ ] `dotnet build` succeeds with the updated package version
- [ ] `dotnet test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URCebMqmTsx6qbH1N59VYY