### PR TITLE
Preserve non-ASCII bytes across string functions in MAJORBBS

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/fscanf_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/fscanf_Tests.cs
@@ -68,6 +68,37 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         }
 
         [Fact]
+        public void fscanf_PreservesNonAsciiBytesInStringConversion()
+        {
+            //Reset State
+            Reset();
+
+            // 0xAD is an invalid single-byte UTF-8 sequence and gets replaced with '?'
+            // if decoded via Encoding.ASCII/UTF8 -- %s must copy it through untouched.
+            var fileBytes = new byte[] { (byte)'a', 0xAD, (byte)'b' };
+            var filePath = Path.Join(mbbsModule.ModulePath, "nonascii.txt");
+            File.WriteAllBytes(filePath, fileBytes);
+
+            var filep = fopen("nonascii.txt", "r");
+            Assert.NotEqual(0, filep.Segment);
+
+            const string FORMAT = "%s";
+            var formatPointer = mbbsEmuMemoryCore.AllocateVariable(null, (ushort)(FORMAT.Length + 1));
+            mbbsEmuMemoryCore.SetArray(formatPointer, Encoding.ASCII.GetBytes(FORMAT));
+
+            var resultPointer = mbbsEmuMemoryCore.AllocateVariable("RESULT", 8);
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, FSCANF_ORDINAL, new List<FarPtr> { filep, formatPointer, resultPointer });
+
+            //Verify Results
+            Assert.Equal(1, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(fileBytes, mbbsEmuMemoryCore.GetArray(resultPointer, (ushort)fileBytes.Length).ToArray());
+
+            Assert.Equal(0, fclose(filep));
+        }
+
+        [Fact]
         public void fscanf_invalid_filestream_Test()
         {
             //Reset State

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/sscanf_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/sscanf_Tests.cs
@@ -260,6 +260,54 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         }
 
         [Fact]
+        public void sscanf_PreservesNonAsciiBytesInStringConversion()
+        {
+            //Reset State
+            Reset();
+
+            // 0xAD is an invalid single-byte UTF-8 sequence and gets replaced with '?'
+            // if decoded via Encoding.ASCII/UTF8 -- %s must copy it through untouched.
+            var inputBytes = new byte[] { (byte)'a', 0xAD, (byte)'b', 0x0 };
+            var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)inputBytes.Length);
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", inputBytes);
+
+            var formatPointer = mbbsEmuMemoryCore.AllocateVariable("FORMAT_STRING", 4);
+            mbbsEmuMemoryCore.SetArray("FORMAT_STRING", Encoding.ASCII.GetBytes("%s"));
+
+            var resultPointer = mbbsEmuMemoryCore.AllocateVariable(null, 8);
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, SSCANF_ORDINAL, new List<FarPtr> { stringPointer, formatPointer, resultPointer });
+
+            //Verify Results
+            Assert.Equal(1, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(new byte[] { (byte)'a', 0xAD, (byte)'b' }, mbbsEmuMemoryCore.GetArray(resultPointer, 3).ToArray());
+        }
+
+        [Fact]
+        public void sscanf_PreservesNonAsciiBytesInCharacterConversion()
+        {
+            //Reset State
+            Reset();
+
+            var inputBytes = new byte[] { 0xAD, 0x0 };
+            var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)inputBytes.Length);
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", inputBytes);
+
+            var formatPointer = mbbsEmuMemoryCore.AllocateVariable("FORMAT_STRING", 4);
+            mbbsEmuMemoryCore.SetArray("FORMAT_STRING", Encoding.ASCII.GetBytes("%c"));
+
+            var resultPointer = mbbsEmuMemoryCore.AllocateVariable(null, 2);
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, SSCANF_ORDINAL, new List<FarPtr> { stringPointer, formatPointer, resultPointer });
+
+            //Verify Results
+            Assert.Equal(1, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(0xAD, mbbsEmuMemoryCore.GetByte(resultPointer));
+        }
+
+        [Fact]
         public void invalid_formatString_throws()
         {
             //Reset State

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/strcmp_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/strcmp_Tests.cs
@@ -50,5 +50,44 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             Assert.Equal(0, mbbsEmuCpuRegisters.AX);
 
         }
+
+        [Fact]
+        public void strcmp_DistinguishesDifferentNonAsciiBytes()
+        {
+            //Reset State
+            Reset();
+
+            // 0x81 and 0xA5 are both invalid single-byte UTF-8 sequences, and both get
+            // replaced with '?' if decoded via Encoding.ASCII/UTF8 -- they must still
+            // compare as different strings.
+            var str1Pointer = mbbsEmuMemoryCore.AllocateVariable("STR1", 2);
+            mbbsEmuMemoryCore.SetArray(str1Pointer, new byte[] { 0x81, 0x0 });
+
+            var str2Pointer = mbbsEmuMemoryCore.AllocateVariable("STR2", 2);
+            mbbsEmuMemoryCore.SetArray(str2Pointer, new byte[] { 0xA5, 0x0 });
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, STRCMP_ORDINAL, new List<FarPtr> { str1Pointer, str2Pointer });
+
+            Assert.NotEqual(0, mbbsEmuCpuRegisters.AX);
+        }
+
+        [Fact]
+        public void strcmp_EqualNonAsciiBytesCompareEqual()
+        {
+            //Reset State
+            Reset();
+
+            var str1Pointer = mbbsEmuMemoryCore.AllocateVariable("STR1", 2);
+            mbbsEmuMemoryCore.SetArray(str1Pointer, new byte[] { 0xAD, 0x0 });
+
+            var str2Pointer = mbbsEmuMemoryCore.AllocateVariable("STR2", 2);
+            mbbsEmuMemoryCore.SetArray(str2Pointer, new byte[] { 0xAD, 0x0 });
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, STRCMP_ORDINAL, new List<FarPtr> { str1Pointer, str2Pointer });
+
+            Assert.Equal(0, mbbsEmuCpuRegisters.AX);
+        }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/stricmp_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/stricmp_Tests.cs
@@ -50,5 +50,64 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             Assert.Equal(0, mbbsEmuCpuRegisters.AX);
 
         }
+
+        [Fact]
+        public void stricmp_DistinguishesDifferentNonAsciiBytes()
+        {
+            //Reset State
+            Reset();
+
+            // 0x81 and 0xA5 are both invalid single-byte UTF-8 sequences, and both get
+            // replaced with '?' if decoded via Encoding.ASCII/UTF8 -- they must still
+            // compare as different strings.
+            var str1Pointer = mbbsEmuMemoryCore.AllocateVariable("STR1", 2);
+            mbbsEmuMemoryCore.SetArray(str1Pointer, new byte[] { 0x81, 0x0 });
+
+            var str2Pointer = mbbsEmuMemoryCore.AllocateVariable("STR2", 2);
+            mbbsEmuMemoryCore.SetArray(str2Pointer, new byte[] { 0xA5, 0x0 });
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, STRICMP_ORDINAL, new List<FarPtr> { str1Pointer, str2Pointer });
+
+            Assert.NotEqual(0, mbbsEmuCpuRegisters.AX);
+        }
+
+        [Fact]
+        public void stricmp_EqualNonAsciiBytesCompareEqual()
+        {
+            //Reset State
+            Reset();
+
+            var str1Pointer = mbbsEmuMemoryCore.AllocateVariable("STR1", 2);
+            mbbsEmuMemoryCore.SetArray(str1Pointer, new byte[] { 0xAD, 0x0 });
+
+            var str2Pointer = mbbsEmuMemoryCore.AllocateVariable("STR2", 2);
+            mbbsEmuMemoryCore.SetArray(str2Pointer, new byte[] { 0xAD, 0x0 });
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, STRICMP_ORDINAL, new List<FarPtr> { str1Pointer, str2Pointer });
+
+            Assert.Equal(0, mbbsEmuCpuRegisters.AX);
+        }
+
+        [Fact]
+        public void stricmp_StillIgnoresAsciiCase()
+        {
+            //Reset State
+            Reset();
+
+            // Confirms the byte-level comparison introduced to fix the non-ASCII
+            // corruption bug didn't regress ASCII case-insensitivity.
+            var str1Pointer = mbbsEmuMemoryCore.AllocateVariable("STR1", 4);
+            mbbsEmuMemoryCore.SetArray(str1Pointer, Encoding.ASCII.GetBytes("AbC"));
+
+            var str2Pointer = mbbsEmuMemoryCore.AllocateVariable("STR2", 4);
+            mbbsEmuMemoryCore.SetArray(str2Pointer, Encoding.ASCII.GetBytes("aBc"));
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, STRICMP_ORDINAL, new List<FarPtr> { str1Pointer, str2Pointer });
+
+            Assert.Equal(0, mbbsEmuCpuRegisters.AX);
+        }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/strncmp_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/strncmp_Tests.cs
@@ -44,5 +44,60 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             Assert.Equal(expected, mbbsEmuCpuRegisters.AX);
         }
+
+        [Fact]
+        public void strncmp_DistinguishesDifferentNonAsciiBytes()
+        {
+            //Reset State
+            Reset();
+
+            // 0x81 and 0xA5 are both invalid single-byte UTF-8 sequences, and both get
+            // replaced with '?' if decoded via Encoding.ASCII/UTF8 -- they must still
+            // compare as different strings.
+            var str1Pointer = mbbsEmuMemoryCore.AllocateVariable("STR1", 2);
+            mbbsEmuMemoryCore.SetArray(str1Pointer, new byte[] { 0x81, 0x0 });
+
+            var str2Pointer = mbbsEmuMemoryCore.AllocateVariable("STR2", 2);
+            mbbsEmuMemoryCore.SetArray(str2Pointer, new byte[] { 0xA5, 0x0 });
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, STRNCMP_ORDINAL,
+                new List<ushort>
+                {
+                    str1Pointer.Offset,
+                    str1Pointer.Segment,
+                    str2Pointer.Offset,
+                    str2Pointer.Segment,
+                    1
+                });
+
+            Assert.NotEqual(0, mbbsEmuCpuRegisters.AX);
+        }
+
+        [Fact]
+        public void strncmp_EqualNonAsciiBytesCompareEqual()
+        {
+            //Reset State
+            Reset();
+
+            var str1Pointer = mbbsEmuMemoryCore.AllocateVariable("STR1", 2);
+            mbbsEmuMemoryCore.SetArray(str1Pointer, new byte[] { 0xAD, 0x0 });
+
+            var str2Pointer = mbbsEmuMemoryCore.AllocateVariable("STR2", 2);
+            mbbsEmuMemoryCore.SetArray(str2Pointer, new byte[] { 0xAD, 0x0 });
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, STRNCMP_ORDINAL,
+                new List<ushort>
+                {
+                    str1Pointer.Offset,
+                    str1Pointer.Segment,
+                    str2Pointer.Offset,
+                    str2Pointer.Segment,
+                    1
+                });
+
+            Assert.Equal(0, mbbsEmuCpuRegisters.AX);
+        }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/strnicmp_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/strnicmp_Tests.cs
@@ -44,5 +44,62 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             Assert.Equal(expected, mbbsEmuCpuRegisters.AX);
         }
+
+        [Fact]
+        public void strnicmp_DistinguishesDifferentNonAsciiBytes()
+        {
+            //Reset State
+            Reset();
+
+            // 0x81 and 0xA5 are both invalid single-byte UTF-8 sequences, and both get
+            // replaced with '?' if decoded via Encoding.ASCII/UTF8 -- they must still
+            // compare as different strings.
+            var str1Pointer = mbbsEmuMemoryCore.AllocateVariable("STR1", 2);
+            mbbsEmuMemoryCore.SetArray(str1Pointer, new byte[] { 0x81, 0x0 });
+
+            var str2Pointer = mbbsEmuMemoryCore.AllocateVariable("STR2", 2);
+            mbbsEmuMemoryCore.SetArray(str2Pointer, new byte[] { 0xA5, 0x0 });
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, STRNICMP_ORDINAL,
+                new List<ushort>
+                {
+                    str1Pointer.Offset,
+                    str1Pointer.Segment,
+                    str2Pointer.Offset,
+                    str2Pointer.Segment,
+                    1
+                });
+
+            Assert.NotEqual(0, mbbsEmuCpuRegisters.AX);
+        }
+
+        [Fact]
+        public void strnicmp_StillIgnoresAsciiCase()
+        {
+            //Reset State
+            Reset();
+
+            // Confirms the byte-level comparison introduced to fix the non-ASCII
+            // corruption bug didn't regress ASCII case-insensitivity.
+            var str1Pointer = mbbsEmuMemoryCore.AllocateVariable("STR1", 4);
+            mbbsEmuMemoryCore.SetArray(str1Pointer, Encoding.ASCII.GetBytes("AbC"));
+
+            var str2Pointer = mbbsEmuMemoryCore.AllocateVariable("STR2", 4);
+            mbbsEmuMemoryCore.SetArray(str2Pointer, Encoding.ASCII.GetBytes("aBc"));
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, STRNICMP_ORDINAL,
+                new List<ushort>
+                {
+                    str1Pointer.Offset,
+                    str1Pointer.Segment,
+                    str2Pointer.Offset,
+                    str2Pointer.Segment,
+                    3
+                });
+
+            Assert.Equal(0, mbbsEmuCpuRegisters.AX);
+        }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/strstr_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/strstr_Tests.cs
@@ -41,5 +41,48 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
                 Assert.Equal(string1Pointer.Segment, mbbsEmuCpuRegisters.DX);
             }
         }
+
+        [Fact]
+        public void STRSTR_FindsNonAsciiNeedle()
+        {
+            //Reset State
+            Reset();
+
+            var haystackPointer = mbbsEmuMemoryCore.AllocateVariable("STRING1", 6);
+            mbbsEmuMemoryCore.SetArray("STRING1", new byte[] { (byte)'a', (byte)'b', 0xAD, (byte)'c', (byte)'d', 0x0 });
+
+            var needlePointer = mbbsEmuMemoryCore.AllocateVariable("STRING2", 2);
+            mbbsEmuMemoryCore.SetArray("STRING2", new byte[] { 0xAD, 0x0 });
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, STRSTR_ORDINAL, new List<FarPtr> { haystackPointer, needlePointer });
+
+            //Verify Results
+            Assert.Equal(haystackPointer.Offset + 2, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(haystackPointer.Segment, mbbsEmuCpuRegisters.DX);
+        }
+
+        [Fact]
+        public void STRSTR_DoesNotFalsePositiveOnDifferentNonAsciiBytes()
+        {
+            //Reset State
+            Reset();
+
+            // 0x81 and 0xA5 are both invalid single-byte UTF-8 sequences, and both get
+            // replaced with '?' if decoded via Encoding.ASCII/UTF8 -- a needle containing
+            // 0xA5 must not "find" a haystack byte of 0x81.
+            var haystackPointer = mbbsEmuMemoryCore.AllocateVariable("STRING1", 4);
+            mbbsEmuMemoryCore.SetArray("STRING1", new byte[] { (byte)'a', 0x81, (byte)'b', 0x0 });
+
+            var needlePointer = mbbsEmuMemoryCore.AllocateVariable("STRING2", 2);
+            mbbsEmuMemoryCore.SetArray("STRING2", new byte[] { 0xA5, 0x0 });
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, STRSTR_ORDINAL, new List<FarPtr> { haystackPointer, needlePointer });
+
+            //Verify Results
+            Assert.Equal(0, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(0, mbbsEmuCpuRegisters.DX);
+        }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/strtok_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/strtok_Tests.cs
@@ -42,5 +42,25 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             Assert.Equal(0, mbbsEmuCpuRegisters.DX);
             Assert.Equal(0, mbbsEmuCpuRegisters.AX);
         }
+
+        [Fact]
+        public void strtok_NonAsciiDelimiter()
+        {
+            //Reset State
+            Reset();
+
+            //Set Argument Values to be Passed In
+            var stringPointer = mbbsEmuMemoryCore.AllocateVariable("STR", 6);
+            mbbsEmuMemoryCore.SetArray("STR", new byte[] { (byte)'a', (byte)'b', 0x80, (byte)'c', (byte)'d', 0x0 });
+
+            var delimPointer = mbbsEmuMemoryCore.AllocateVariable("DELIM", 2);
+            mbbsEmuMemoryCore.SetArray("DELIM", new byte[] { 0x80, 0x0 });
+
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, STRTOK_ORDINAL, new List<FarPtr> { stringPointer, delimPointer });
+            Assert.Equal("ab", Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString(mbbsEmuCpuRegisters.DX, mbbsEmuCpuRegisters.AX, true)));
+
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, STRTOK_ORDINAL, new List<FarPtr> { FarPtr.Empty, delimPointer });
+            Assert.Equal("cd", Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString(mbbsEmuCpuRegisters.DX, mbbsEmuCpuRegisters.AX, true)));
+        }
     }
 }

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -3867,7 +3867,9 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// </summary>
         private void sscanf()
         {
-            var inputString = GetParameterString(0, stripNull: true);
+            // Decoded via Latin1 (not ASCII) so each byte maps 1:1 to a char (0-255)
+            // instead of collapsing anything >= 0x80 to '?' before scanf() parses it.
+            var inputString = Encoding.Latin1.GetString(GetParameterStringSpan(0, stripNull: true));
             var formatString = GetParameterString(2, stripNull: true);
             scanf(inputString.GetEnumerator(), formatString, 4);
         }
@@ -4013,7 +4015,9 @@ namespace MBBSEmu.HostProcess.ExportedModules
                         });
 
                         var destinationPtr = GetParameterPointer(startingParameterOrdinal);
-                        Module.Memory.SetArray(destinationPtr, Encoding.ASCII.GetBytes(stringValue));
+                        // Latin1 maps each char (0-255) straight back to its original byte,
+                        // unlike ASCII which would collapse anything >= 0x80 to '?'.
+                        Module.Memory.SetArray(destinationPtr, Encoding.Latin1.GetBytes(stringValue));
 
                         if (stringValue.Length > 0)
                             ++matches;
@@ -4629,8 +4633,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
         private void strstr()
         {
             var stringToSearchPointer = GetParameterPointer(0);
-            var stringToSearch = GetParameterString(0, true);
-            var stringToFind = GetParameterString(2, true);
+            var stringToSearch = GetParameterStringSpan(0, true);
+            var stringToFind = GetParameterStringSpan(2, true);
 
             var offset = stringToSearch.IndexOf(stringToFind);
             if (offset >= 0)
@@ -4748,8 +4752,9 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// </summary>
         private void strcmp()
         {
-            var string1 = GetParameterString(0, stripNull: true);
-            var string2 = GetParameterString(2, stripNull: true);
+            // Latin1 (not ASCII) so bytes >= 0x80 decode 1:1 instead of collapsing to '?'
+            var string1 = Encoding.Latin1.GetString(GetParameterStringSpan(0, stripNull: true));
+            var string2 = Encoding.Latin1.GetString(GetParameterStringSpan(2, stripNull: true));
 
             Registers.AX = (ushort)string.Compare(string1, string2);
         }
@@ -5268,10 +5273,10 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var workPointer = Module.Memory.GetPointer(workPointerPointer);
             var endOffset = Module.Memory.GetWord(lengthPointer);
 
-            var stringDelimiter = Encoding.ASCII.GetString(Module.Memory.GetString(stringDelimitersPointer, stripNull: true));
+            var stringDelimiter = Module.Memory.GetString(stringDelimitersPointer, stripNull: true);
 
             // skip starting delimiters
-            while (workPointer.Offset < endOffset && stringDelimiter.Contains((char)Module.Memory.GetByte(workPointer)))
+            while (workPointer.Offset < endOffset && stringDelimiter.Contains(Module.Memory.GetByte(workPointer)))
             {
                 Module.Memory.SetByte(workPointer++, 0x0);
             }
@@ -5288,7 +5293,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             Registers.SetPointer(workPointer);
 
             // scan until we find the next delimiter and then null it out for the return
-            while (workPointer.Offset < endOffset && !stringDelimiter.Contains((char)Module.Memory.GetByte(workPointer)))
+            while (workPointer.Offset < endOffset && !stringDelimiter.Contains(Module.Memory.GetByte(workPointer)))
             {
                 workPointer++;
             }
@@ -5426,10 +5431,10 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// </summary>
         private void stricmp()
         {
-            var string1 = GetParameterPointer(0) == FarPtr.Empty ? string.Empty : GetParameterString(0, stripNull: true);
-            var string2 = GetParameterPointer(2) == FarPtr.Empty ? string.Empty : GetParameterString(2, stripNull: true);
+            var string1 = GetParameterPointer(0) == FarPtr.Empty ? ReadOnlySpan<byte>.Empty : GetParameterStringSpan(0, stripNull: true);
+            var string2 = GetParameterPointer(2) == FarPtr.Empty ? ReadOnlySpan<byte>.Empty : GetParameterStringSpan(2, stripNull: true);
 
-            Registers.AX = (ushort)string.Compare(string1, string2, ignoreCase: true);
+            Registers.AX = (ushort)Math.Sign(CompareBytesIgnoreCase(string1, string2));
         }
 
         /// <summary>
@@ -6646,11 +6651,34 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// </summary>
         private void strnicmp()
         {
-            var string1 = GetParameterString(0, stripNull: true);
-            var string2 = GetParameterString(2, stripNull: true);
+            var string1 = GetParameterStringSpan(0, stripNull: true);
+            var string2 = GetParameterStringSpan(2, stripNull: true);
             var maxLength = GetParameter(4);
 
-            Registers.AX = (ushort)string.Compare(string1, 0, string2, 0, maxLength, true);
+            string1 = string1.Slice(0, Math.Min(string1.Length, maxLength));
+            string2 = string2.Slice(0, Math.Min(string2.Length, maxLength));
+
+            Registers.AX = (ushort)Math.Sign(CompareBytesIgnoreCase(string1, string2));
+        }
+
+        /// <summary>
+        ///     Compares two byte spans case-insensitively (ASCII letters only), mirroring the
+        ///     semantics of C's stricmp/strnicmp without corrupting bytes >= 0x80 the way a
+        ///     string.Compare(ignoreCase: true) over an ASCII-decoded string would.
+        /// </summary>
+        private static int CompareBytesIgnoreCase(ReadOnlySpan<byte> string1, ReadOnlySpan<byte> string2)
+        {
+            var minLength = Math.Min(string1.Length, string2.Length);
+            for (var i = 0; i < minLength; i++)
+            {
+                var diff = ToLowerAscii(string1[i]) - ToLowerAscii(string2[i]);
+                if (diff != 0)
+                    return diff;
+            }
+
+            return string1.Length - string2.Length;
+
+            static byte ToLowerAscii(byte b) => b is >= (byte)'A' and <= (byte)'Z' ? (byte)(b + 0x20) : b;
         }
 
         /// <summary>
@@ -6673,8 +6701,9 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// </summary>
         private void strncmp()
         {
-            var string1 = GetParameterString(0, stripNull: true);
-            var string2 = GetParameterString(2, stripNull: true);
+            // Latin1 (not ASCII) so bytes >= 0x80 decode 1:1 instead of collapsing to '?'
+            var string1 = Encoding.Latin1.GetString(GetParameterStringSpan(0, stripNull: true));
+            var string2 = Encoding.Latin1.GetString(GetParameterStringSpan(2, stripNull: true));
             var maxLength = GetParameter(4);
 
             Registers.AX = (ushort)string.Compare(string1, 0, string2, 0, maxLength);


### PR DESCRIPTION
## Summary
- `sscanf`/`scanf` (`%s`, `%c`), `strstr`, `strcmp`, `strncmp`, `stricmp`, `strnicmp`, and `strtok` all decoded parameters through `Encoding.ASCII` (or compared strings decoded that way), which collapses any byte >= 0x80 to `'?'` before it's compared, searched, or written back to module memory — the same class of bug fixed for `strncpy` in #701.
- `sscanf`/`scanf` and `strstr`/`strtok` now operate on raw bytes (or `Latin1`, which maps 0-255 1:1) instead of `ASCII`.
- `strcmp`/`strncmp` keep .NET's culture-aware `string.Compare` (needed to preserve the existing ASCII case-ordering behavior the test suite encodes) but decode via `Latin1` so distinct high bytes no longer collapse to the same `'?'`.
- `stricmp`/`strnicmp` switch to a byte-level ASCII-only case fold instead of a culture-aware compare over a lossy decode.

## Test plan
- [x] Added non-ASCII byte-preservation tests for `sscanf`, `fscanf`, `strstr`, `strcmp`, `strncmp`, `stricmp`, `strtok`
- [x] Added a regression check that `stricmp`/`strnicmp` still ignore ASCII case correctly
- [x] `dotnet test` — full suite passes (2731/2731)

🤖 Generated with [Claude Code](https://claude.com/claude-code)