### PR TITLE
Resolve inter-module imports by name, with correct ordinal handling for movable exports

### DIFF
--- a/MBBSEmu.Tests/Disassembler/NEFile_Tests.cs
+++ b/MBBSEmu.Tests/Disassembler/NEFile_Tests.cs
@@ -1,0 +1,98 @@
+using System;
+using MBBSEmu.Disassembler;
+using MBBSEmu.Logging;
+using Xunit;
+
+namespace MBBSEmu.Tests.Disassembler
+{
+    /// <summary>
+    ///     Regression tests for NE (New Executable) file parsing, in particular
+    ///     the Entry Table, which is used to resolve named exports to a
+    ///     segment:offset pair during module relocation/import resolution.
+    /// </summary>
+    public class NEFile_Tests
+    {
+        private const ushort WindowsHeaderOffset = 0x40;
+
+        /// <summary>
+        ///     Builds a minimal, synthetic NE file containing a single
+        ///     "movable" Entry Table bundle (segment marker 0xFF) with one
+        ///     entry, so we can assert the parsed <see cref="MBBSEmu.Disassembler.Artifacts.Entry"/>
+        ///     gets a correct, non-zero Ordinal.
+        ///
+        ///     Segment/Resource/Resident-Name/Module-Reference/Imported-Name
+        ///     tables are all intentionally empty (entry counts of 0) so the
+        ///     test only exercises Entry Table + Non-Resident Name Table
+        ///     parsing.
+        /// </summary>
+        private static byte[] BuildMinimalNeFileWithMovableEntry(byte segmentNumber, ushort offset)
+        {
+            const int entryTableRelativeOffset = 0x3F; // right after the 0x3F-byte NE header
+            var entryTableOffset = WindowsHeaderOffset + entryTableRelativeOffset; // 127
+
+            // Entry table bytes: [entryCount=1][segment=0xFF][flag][pad][pad][segmentNumber][offsetLo][offsetHi]
+            var entryTableBytes = new byte[]
+            {
+                0x01,           // entryCount (also doubles as the "bundle count" hint read before the loop)
+                0xFF,           // 0xFF => movable segment marker
+                0x03,           // Flag (arbitrary "exported" style flag)
+                0xCD, 0x3F,     // padding / historically "INT 3Fh" opcode bytes, unused by the parser
+                segmentNumber,  // actual segment number for this movable entry
+                (byte)(offset & 0xFF),
+                (byte)((offset >> 8) & 0xFF)
+            };
+
+            var nonResidentNameTableOffset = (uint)(entryTableOffset + entryTableBytes.Length);
+
+            var fileLength = nonResidentNameTableOffset + 1; // +1 byte of headroom, table length is 0
+            var file = new byte[fileLength];
+
+            // --- MZ (DOS) Header ---
+            file[0] = (byte)'M';
+            file[1] = (byte)'Z';
+            file[0x18] = 0x40; // signals "extended header present" per NEFile.Load()
+            BitConverter.GetBytes(WindowsHeaderOffset).CopyTo(file, 0x3C);
+
+            // --- NE (Windows) Header, 0x3F bytes starting at WindowsHeaderOffset ---
+            var h = WindowsHeaderOffset;
+            file[h + 0x00] = (byte)'N';
+            file[h + 0x01] = (byte)'E';
+            BitConverter.GetBytes((ushort)entryTableRelativeOffset).CopyTo(file, h + 0x04); // EntryTableOffset (relative)
+            BitConverter.GetBytes((ushort)entryTableBytes.Length).CopyTo(file, h + 0x06);   // EntryTableLength
+            BitConverter.GetBytes((ushort)0).CopyTo(file, h + 0x1C);  // SegmentTableEntries
+            BitConverter.GetBytes((ushort)0).CopyTo(file, h + 0x1E);  // ModuleReferenceTableEntries
+            BitConverter.GetBytes((ushort)0).CopyTo(file, h + 0x20);  // NonResidentNameTableLength
+            BitConverter.GetBytes((ushort)0).CopyTo(file, h + 0x22);  // SegmentTableOffset (relative, unused - 0 entries)
+            BitConverter.GetBytes((ushort)0).CopyTo(file, h + 0x24);  // ResourceTableOffset (relative, unused)
+            // ResidentNameTableOffset (relative): point at the trailing zero-length
+            // headroom byte so the "end of names" check (length byte == 0) fires
+            // on the very first iteration.
+            BitConverter.GetBytes((ushort)(entryTableRelativeOffset + entryTableBytes.Length)).CopyTo(file, h + 0x26);
+            BitConverter.GetBytes((ushort)0).CopyTo(file, h + 0x28);  // ModuleReferenceTableOffset (relative, unused - 0 entries)
+            BitConverter.GetBytes((ushort)0).CopyTo(file, h + 0x2A);  // ImportedNamesTableOffset (relative, unused - 0 entries)
+            BitConverter.GetBytes(nonResidentNameTableOffset).CopyTo(file, h + 0x2C); // NonResidentNameTableOffset (ABSOLUTE)
+
+            // --- Entry Table ---
+            entryTableBytes.CopyTo(file, entryTableOffset);
+
+            return file;
+        }
+
+        [Fact]
+        public void Load_MovableEntryTableBundle_AssignsNonZeroOrdinal()
+        {
+            var fileContent = BuildMinimalNeFileWithMovableEntry(segmentNumber: 1, offset: 0x1234);
+
+            var neFile = new NEFile(new MessageLogger(), fullFilePath: "test.dll", data: fileContent);
+
+            var entry = Assert.Single(neFile.EntryTable);
+
+            // Before the fix, movable entries never had their Ordinal assigned
+            // and were left at the default value of 0, which meant named-export
+            // lookups (e.g. MbbsHost.First) could never find them.
+            Assert.Equal(1, entry.Ordinal);
+            Assert.Equal(1, entry.SegmentNumber);
+            Assert.Equal(0x1234, entry.Offset);
+        }
+    }
+}

--- a/MBBSEmu/Disassembler/NEFile.cs
+++ b/MBBSEmu/Disassembler/NEFile.cs
@@ -221,6 +221,7 @@ namespace MBBSEmu.Disassembler
                             entry.Offset =
                                 BitConverter.ToUInt16(FileContent,
                                     WindowsHeader.EntryTableOffset + entryByteOffset + 6 + entrySize * i);
+                            entry.Ordinal = entryOrdinal;   //Same ordinal shift as the fixed-segment case above
                         }
                         entryOrdinal++;
                         EntryTable.Add(entry);

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -1,6 +1,7 @@
 using MBBSEmu.Database.Repositories.Account;
 using MBBSEmu.Database.Repositories.AccountKey;
 using MBBSEmu.Date;
+using MBBSEmu.Disassembler;
 using MBBSEmu.Disassembler.Artifacts;
 using MBBSEmu.DOS;
 using MBBSEmu.Extensions;
@@ -26,6 +27,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 
 namespace MBBSEmu.HostProcess
@@ -1225,6 +1227,35 @@ namespace MBBSEmu.HostProcess
         ///     0x004D == 77, Ordinal for ATOL()
         /// </summary>
         /// <param name="module"></param>
+        /// <summary>
+        ///     Reads a length-prefixed name string from a DLL's Imported Names Table at the given
+        ///     offset. IMPORTNAME relocation records store the imported function name as an offset
+        ///     into this table.
+        /// </summary>
+        private static string GetImportedNameByOffset(NEFile file, ushort offset)
+        {
+            var fileOffset = file.WindowsHeader.ImportedNamesTableOffset + offset;
+            var length = file.FileContent[fileOffset];
+            return Encoding.ASCII.GetString(file.FileContent, fileOffset + 1, length);
+        }
+
+        /// <summary>
+        ///     Resolves an exported function name to its Entry Table ordinal within the given DLL by
+        ///     searching the Resident and Non-Resident Name Tables. Returns 0 if the name is not found.
+        /// </summary>
+        private static ushort ResolveExportedOrdinalByName(NEFile file, string name)
+        {
+            foreach (var residentName in file.ResidentNameTable)
+                if (string.Equals(residentName.Name, name, StringComparison.OrdinalIgnoreCase))
+                    return residentName.IndexIntoEntryTable;
+
+            foreach (var nonResidentName in file.NonResidentNameTable)
+                if (string.Equals(nonResidentName.Name, name, StringComparison.OrdinalIgnoreCase))
+                    return nonResidentName.IndexIntoEntryTable;
+
+            return 0;
+        }
+
         private void PatchRelocation(MbbsModule module)
         {
 
@@ -1338,20 +1369,59 @@ namespace MBBSEmu.HostProcess
                                 {
                                     var nametableOrdinal = relocationRecord.TargetTypeValueTuple.Item2;
                                     var functionOrdinal = relocationRecord.TargetTypeValueTuple.Item3;
+                                    var importedModuleName = dll.File.ImportedNameTable[nametableOrdinal].Name;
 
-                                    var newSegment = dll.File.ImportedNameTable[nametableOrdinal].Name switch
+                                    FarPtr relocationPointer;
+                                    switch (importedModuleName)
                                     {
-                                        "MAJORBBS" => Majorbbs.Segment,
-                                        "GALGSBL" => Galgsbl.Segment,
-                                        "PHAPI" => Phapi.Segment,
-                                        "GALME" => Galme.Segment,
-                                        "DOSCALLS" => Doscalls.Segment,
-                                        _ => throw new Exception(
-                                            $"Unknown or Unimplemented Imported Module: {dll.File.ImportedNameTable[nametableOrdinal].Name}")
+                                        case "MAJORBBS":
+                                            relocationPointer = new FarPtr(Majorbbs.Segment, functionOrdinal);
+                                            break;
+                                        case "GALGSBL":
+                                            relocationPointer = new FarPtr(Galgsbl.Segment, functionOrdinal);
+                                            break;
+                                        case "PHAPI":
+                                            relocationPointer = new FarPtr(Phapi.Segment, functionOrdinal);
+                                            break;
+                                        case "GALME":
+                                            relocationPointer = new FarPtr(Galme.Segment, functionOrdinal);
+                                            break;
+                                        case "DOSCALLS":
+                                            relocationPointer = new FarPtr(Doscalls.Segment, functionOrdinal);
+                                            break;
+                                        case "GALMSG":
+                                            relocationPointer = new FarPtr(Galmsg.Segment, functionOrdinal);
+                                            break;
+                                        //Imported by name from another module DLL loaded alongside this one
+                                        //(e.g. MajorMUD Plus (WCCMMPLS) imports functions from MajorMUD (WCCMMUD)).
+                                        //For an IMPORTNAME relocation the target value is an offset into this DLL's
+                                        //imported-names table pointing at the function name; we resolve that name to
+                                        //an exported ordinal in the target DLL and build a pointer into its segments.
+                                        case var importedName
+                                            when module.ModuleDlls.Any(m =>
+                                                m.File.FileName.Split('.')[0].ToUpper() == importedName.ToUpper()):
+                                            {
+                                                var importedDll = module.ModuleDlls.First(m =>
+                                                    m.File.FileName.Split('.')[0].ToUpper() == importedName.ToUpper());
 
-                                    };
+                                                var importedFunctionName = GetImportedNameByOffset(dll.File, functionOrdinal);
+                                                var entryOrdinal = ResolveExportedOrdinalByName(importedDll.File, importedFunctionName);
 
-                                    var relocationPointer = new FarPtr(newSegment, functionOrdinal);
+                                                if (entryOrdinal == 0)
+                                                    throw new Exception(
+                                                        $"({module.ModuleIdentifier}) Unable to resolve imported name '{importedFunctionName}' from module {importedName}");
+
+                                                var importedEntry =
+                                                    importedDll.File.EntryTable.First(x => x.Ordinal == entryOrdinal);
+                                                relocationPointer = new FarPtr(
+                                                    (ushort)(importedEntry.SegmentNumber + importedDll.SegmentOffset),
+                                                    importedEntry.Offset);
+                                                break;
+                                            }
+                                        default:
+                                            throw new Exception(
+                                                $"Unknown or Unimplemented Imported Module: {importedModuleName}");
+                                    }
 
                                     //32-Bit Pointer
                                     if (relocationRecord.SourceType == 3)


### PR DESCRIPTION
Adds support for resolving IMPORTNAME/IMPORTNAMEADDITIVE records against other modules loaded into the same session (e.g. MajorMUD Plus importing from MajorMUD), extending the existing IMPORTORDINAL inter-module resolution path. Previously this case threw Unknown or Unimplemented Imported Module for anything outside the built-in SDK libraries.

While reviewing this path, found that NEFile.Load() only assigned Ordinal to fixed-segment Entry Table entries, leaving every movable-bundle entry (segment marker 0xFF) at the default 0. Since the new named-import resolution searches EntryTable by ordinal, any target export living in a movable bundle would fail lookup and abort the importing module's startup included here as a one-line fix plus a regression test (NEFile_Tests.cs) covering movable-entry ordinal assignment.